### PR TITLE
fix: rejoin always resyncs the socket; stop linting agent worktrees

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,7 @@ playwright-report/
 *.tsbuildinfo
 .DS_Store
 .claude/settings.local.json
+.claude/worktrees/
+.claude/context/
+.agents/
+skills-lock.json

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -5,6 +5,9 @@ import tseslint from 'typescript-eslint';
 export default tseslint.config(
   {
     ignores: [
+      // Agent worktrees are full checkouts of this repo nested inside it — linting them
+      // double-reports every finding and breaks `pnpm gate` whenever a loop is in flight.
+      '.claude/**',
       '**/dist/**',
       '**/node_modules/**',
       '**/.wrangler/**',

--- a/party/src/session.test.ts
+++ b/party/src/session.test.ts
@@ -102,6 +102,44 @@ describe('rejoin', () => {
     expect(state.participants[participantId]?.connected).toBe(true);
     expect(Object.keys(state.participants)).toHaveLength(1);
   });
+
+  // Tenet 6 vs Invariant 5: an idempotent reconnect retry reuses its intentId, which the
+  // reducer correctly treats as a no-op emitting no events. The socket must still resync.
+  it('answers a replayed rejoin intentId with a full snapshot instead of hanging', async () => {
+    const { code } = await createSession();
+    const socket1 = await connect(code);
+    const { participantId, participantToken } = await join(socket1, 'Facilitator');
+
+    const intentId = crypto.randomUUID();
+    const rejoin = { type: 'rejoin', intentId, participantId, token: participantToken };
+
+    const socket2 = await connect(code);
+    socket2.send(rejoin);
+    expect((await socket2.next()).type).toBe('state');
+
+    // Same intentId again — the reducer no-ops, but this socket still gets its snapshot.
+    socket2.send(rejoin);
+    const replayed = await socket2.next();
+    expect(replayed.type).toBe('state');
+    expect((replayed as { state: SessionState }).state.participants[participantId]?.connected).toBe(true);
+  });
+
+  it('does not send the rejoining socket a duplicate snapshot', async () => {
+    const { code } = await createSession();
+    const socket1 = await connect(code);
+    const { participantId, participantToken } = await join(socket1, 'Facilitator');
+
+    const socket2 = await connect(code);
+    socket2.send({ type: 'rejoin', intentId: crypto.randomUUID(), participantId, token: participantToken });
+    expect((await socket2.next()).type).toBe('state');
+
+    const race = await Promise.race([
+      socket2.next().then(() => 'message'),
+      new Promise((resolve) => setTimeout(() => resolve('timeout'), 100)),
+    ]);
+    expect(race).toBe('timeout');
+    expect(socket2.received).toBe(1);
+  });
 });
 
 describe('config lock', () => {

--- a/party/src/session.ts
+++ b/party/src/session.ts
@@ -137,11 +137,21 @@ export class SessionServer extends Server<Env> {
       }
     } else if (intent.type === 'rejoin') {
       connection.setState({ participantId: intent.participantId });
+      // Tenet 6 (reconnect = resync) is a per-socket concern, not a per-state-change one:
+      // this socket needs the full snapshot regardless of whether the session mutated. A
+      // replayed rejoin intentId — exactly what an idempotent reconnect retry looks like
+      // after a dropped socket — is a correct no-op in the reducer and emits no events, so
+      // relying on the broadcast below would leave the reconnecting client hanging forever.
+      connection.send(JSON.stringify({ type: 'state', state: this.session } satisfies Event));
     }
 
     if (changed) {
+      // The rejoining socket already got its snapshot directly above; excluding it here
+      // avoids sending the same full state twice. Invariant 5 is unaffected — a replayed
+      // intent still mutates nothing and still broadcasts nothing to anyone else.
+      const without = intent.type === 'rejoin' ? [connection.id] : [];
       for (const event of result.events) {
-        this.broadcast(JSON.stringify(event));
+        this.broadcast(JSON.stringify(event), without);
       }
     }
   }


### PR DESCRIPTION
The follow-up flagged on #41, fixed before 01.2 builds on it — plus a build-hygiene fix found while verifying it.

## 1. A replayed `rejoin` left the client hanging

Tenet 6 (*reconnect = resync*) and Invariant 5 (*replayed intents are no-ops*) collided.

An idempotent reconnect retry after a dropped socket reuses its `intentId`. The reducer correctly treats that as a no-op and emits no events, so `changed` was `false` and the DO broadcast nothing — **the reconnecting client waited forever for a snapshot it would never receive.**

The fix separates the two concerns: resync is about what *this socket* knows, not about whether the session mutated. The DO now always answers a rejoin on that connection with a full snapshot, and excludes that socket from the subsequent broadcast so the same state isn't sent twice.

Invariant 5 is untouched — a replayed intent still mutates nothing and still broadcasts nothing to anyone else. `party/src/idempotency.test.ts` exercises invariant 5 via `reportProgress`, not `rejoin`, so the two don't interfere.

New tests:
- a replayed rejoin `intentId` gets a snapshot instead of hanging (this is the regression test for the bug)
- the rejoining socket receives exactly one snapshot, not a duplicate

## 2. `pnpm gate` broke whenever an agent worktree existed

Not related to the above — found because it blocked verification.

Agent worktrees live in `.claude/worktrees/`, which are **full checkouts of this repo nested inside it**. ESLint had no ignore for them, so it linted every copy. Worse, their `scripts/**/*.mjs` fall outside the root `files` pattern that supplies node globals, producing 132 phantom `no-undef` errors on `process` and `console`:

```
✖ 132 problems (132 errors, 0 warnings)
```

So any local `pnpm gate` run failed while a loop was in flight — nothing to do with the code under test. Fixed by adding `.claude/**` to the ESLint ignores. Also gitignored `.claude/worktrees/`, `.claude/context/`, `.agents/` and `skills-lock.json` so agent scaffolding stops showing up as untracked noise in `git status`.

## Test evidence

```
Test Files  22 passed (22)
     Tests  157 passed (157)
  24 passed (15.1s)   [Playwright e2e]
```

## Merge order

Worth merging **before** 01.2 (Client session layer) starts, since that spec owns reconnect and would otherwise inherit the hang.

🤖 Generated with [Claude Code](https://claude.com/claude-code)