### PR TITLE
feat(01.4): Round flow

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -11,6 +11,9 @@
     "test": "vitest run"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@fontsource/fraunces": "^5.3.0",
     "@values-cards/shared": "workspace:*",
     "framer-motion": "^12.43.0",

--- a/app/src/engine-ui/RankBoard.tsx
+++ b/app/src/engine-ui/RankBoard.tsx
@@ -1,0 +1,132 @@
+import {
+  DndContext,
+  KeyboardSensor,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type Announcements,
+  type DragEndEvent,
+} from '@dnd-kit/core';
+import {
+  SortableContext,
+  arrayMove,
+  sortableKeyboardCoordinates,
+  useSortable,
+  verticalListSortingStrategy,
+} from '@dnd-kit/sortable';
+import { CSS } from '@dnd-kit/utilities';
+import type { Card } from '@values-cards/shared';
+import { Button } from '../components/Button';
+
+export interface RankBoardProps {
+  /** Final cards, in current rank order (most important first). */
+  cards: Card[];
+  onReorder: (order: string[]) => void;
+  onConfirm: () => void;
+}
+
+interface RankItemProps {
+  card: Card;
+  position: number;
+}
+
+function RankItem({ card, position }: RankItemProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: card.value,
+  });
+
+  return (
+    <li
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition: transition ?? undefined }}
+      className={`flex items-center gap-4 rounded-card bg-surface-raised p-4 shadow-card ${isDragging ? 'opacity-60' : ''}`}
+    >
+      <button
+        type="button"
+        {...attributes}
+        {...listeners}
+        aria-label={`Reorder ${card.value}, position ${position} of list`}
+        aria-roledescription="sortable"
+        className="flex min-h-11 min-w-11 shrink-0 cursor-grab items-center justify-center rounded-control text-xl text-ink-muted active:cursor-grabbing"
+      >
+        ⠿
+      </button>
+      <div>
+        <p className="font-display font-semibold text-ink">
+          {position}. {card.value}
+        </p>
+        {card.description ? <p className="text-sm text-ink-muted">{card.description}</p> : null}
+      </div>
+    </li>
+  );
+}
+
+/**
+ * Final round only (`rounds[last].rank === true`): drag-to-order the kept
+ * cards with a pointer or the keyboard sensor alone (space to lift, arrows
+ * to move, space to drop — dnd-kit defaults). A conditional phase of the
+ * same sort flow, not a separate page.
+ */
+export function RankBoard({ cards, onReorder, onConfirm }: RankBoardProps) {
+  const sensors = useSensors(
+    useSensor(PointerSensor),
+    useSensor(KeyboardSensor, { coordinateGetter: sortableKeyboardCoordinates }),
+  );
+
+  function titleFor(id: string): string {
+    return cards.find((card) => card.value === id)?.value ?? String(id);
+  }
+
+  function positionFor(id: string): number {
+    return cards.findIndex((card) => card.value === id) + 1;
+  }
+
+  const announcements: Announcements = {
+    onDragStart({ active }) {
+      return `Picked up ${titleFor(String(active.id))} at position ${positionFor(String(active.id))}.`;
+    },
+    onDragOver({ active, over }) {
+      if (!over) return undefined;
+      return `${titleFor(String(active.id))} moved to position ${positionFor(String(over.id))}.`;
+    },
+    onDragEnd({ active, over }) {
+      if (!over) return `${titleFor(String(active.id))} dropped.`;
+      return `${titleFor(String(active.id))} dropped at position ${positionFor(String(over.id))}.`;
+    },
+    onDragCancel({ active }) {
+      return `Reordering ${titleFor(String(active.id))} cancelled.`;
+    },
+  };
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = cards.findIndex((card) => card.value === active.id);
+    const newIndex = cards.findIndex((card) => card.value === over.id);
+    if (oldIndex === -1 || newIndex === -1) return;
+    onReorder(arrayMove(cards, oldIndex, newIndex).map((card) => card.value));
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+      <h1 className="font-display text-2xl font-semibold">Rank your final cards</h1>
+      <p className="text-sm text-ink-muted">Drag to reorder, most important first.</p>
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        accessibility={{ announcements }}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={cards.map((card) => card.value)} strategy={verticalListSortingStrategy}>
+          <ol className="flex w-full max-w-md flex-col gap-3">
+            {cards.map((card, index) => (
+              <RankItem key={card.value} card={card} position={index + 1} />
+            ))}
+          </ol>
+        </SortableContext>
+      </DndContext>
+      <Button onClick={onConfirm}>Confirm order</Button>
+    </main>
+  );
+}

--- a/app/src/engine-ui/SortRound.test.tsx
+++ b/app/src/engine-ui/SortRound.test.tsx
@@ -54,11 +54,14 @@ describe('SortRound', () => {
     await waitFor(() => expect(screen.getByRole('status', { hidden: true }).textContent).toBe(`Discarded ${first}`));
   });
 
-  it('shows the "Round complete" placeholder once the queue empties', async () => {
+  it('renders no card once the queue empties — 01.4 (routes/Sort) owns what comes next', async () => {
     const cfg = config(1, 1);
     renderRound(cfg);
     const cardValue = 'Card 0';
     await userEvent.click(screen.getByRole('button', { name: `Keep ${cardValue}` }));
-    await waitFor(() => expect(screen.getByText('Round complete')).toBeDefined(), { timeout: 3000 });
+    await waitFor(() => expect(screen.queryByRole('group', { name: `${cardValue} card` })).toBeNull(), {
+      timeout: 3000,
+    });
+    expect(screen.queryByRole('button', { name: /^Keep /, hidden: true })).toBeNull();
   });
 });

--- a/app/src/engine-ui/SortRound.tsx
+++ b/app/src/engine-ui/SortRound.tsx
@@ -12,8 +12,10 @@ export interface SortRoundProps {
 
 /**
  * Config-driven sort screen: renders whichever round `config.rounds` and the
- * store's `round` point to. End of queue shows a placeholder — trim/advance
- * to the next round is 01.4.
+ * store's `round` point to. Owns only the active-sorting phase — once the
+ * queue empties, the caller (routes/Sort, 01.4) reads the store's phase and
+ * swaps this out for the round-complete/trim/rank/result screen instead, so
+ * this renders nothing itself in that instant.
  */
 export function SortRound({ config, useSortStore }: SortRoundProps) {
   const state = useSortStore();
@@ -65,7 +67,12 @@ export function SortRound({ config, useSortStore }: SortRoundProps) {
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}
       </div>
-      <ProgressRail roundName={roundCfg.name} position={Math.min(position, total)} total={total} />
+      <div className="flex flex-col items-center gap-1">
+        <ProgressRail roundName={roundCfg.name} position={Math.min(position, total)} total={total} />
+        {/* ponytail: a plain running total, not an animated discard-stack visual — nothing in the
+            acceptance criteria requires the motion, and the count is what's load-bearing. */}
+        <p className="text-xs text-ink-muted">{state.totalDiscarded + state.discarded.length} set aside</p>
+      </div>
       {currentCard ? (
         <CardStack
           card={currentCard}
@@ -74,9 +81,7 @@ export function SortRound({ config, useSortStore }: SortRoundProps) {
           onKeep={() => useSortStore.getState().keep(currentCard.value)}
           onDiscard={() => useSortStore.getState().discard(currentCard.value)}
         />
-      ) : (
-        <p className="font-display text-2xl font-semibold">Round complete</p>
-      )}
+      ) : null}
       <KeptTray
         cards={keptCards}
         limit={roundCfg.keep}

--- a/app/src/engine-ui/TrimGrid.tsx
+++ b/app/src/engine-ui/TrimGrid.tsx
@@ -1,0 +1,123 @@
+import { useEffect, useRef, useState, type KeyboardEvent } from 'react';
+import type { Card } from '@values-cards/shared';
+import { Button } from '../components/Button';
+import { GameCard } from '../components/GameCard';
+
+export interface TrimGridProps {
+  /** The over-limit kept cards, in keep order. */
+  cards: Card[];
+  /** Card ids currently marked to cut, pending confirm. */
+  cut: string[];
+  limit: number;
+  onToggleCut: (cardId: string) => void;
+  onConfirm: () => void;
+}
+
+// Matches the sm:grid-cols-3 breakpoint below — only used for Up/Down arrow
+// math, so it doesn't need to track every breakpoint exactly to be operable.
+const GRID_COLUMNS = 3;
+
+/**
+ * Conditional phase of the sort flow (not a page): a responsive grid of the
+ * over-limit kept cards, tap/Enter toggles a card as cut. Roving tabindex
+ * keeps the whole grid on one Tab stop; arrow keys move focus within it.
+ */
+export function TrimGrid({ cards, cut, limit, onToggleCut, onConfirm }: TrimGridProps) {
+  const [focusIndex, setFocusIndex] = useState(0);
+  const itemRefs = useRef<(HTMLButtonElement | null)[]>([]);
+  const [announcement, setAnnouncement] = useState('');
+  const prevCutRef = useRef(cut);
+
+  useEffect(() => {
+    const prev = prevCutRef.current;
+    const added = cut.find((id) => !prev.includes(id));
+    const removed = prev.find((id) => !cut.includes(id));
+    if (added !== undefined) {
+      setAnnouncement(`${added} cut`);
+    } else if (removed !== undefined) {
+      setAnnouncement(`${removed} restored`);
+    }
+    prevCutRef.current = cut;
+  }, [cut]);
+
+  const remainingToCut = Math.max(0, cards.length - cut.length - limit);
+  const canConfirm = cards.length - cut.length <= limit;
+
+  function moveFocus(nextIndex: number) {
+    const clamped = Math.max(0, Math.min(cards.length - 1, nextIndex));
+    setFocusIndex(clamped);
+    itemRefs.current[clamped]?.focus();
+  }
+
+  function onKeyDown(event: KeyboardEvent<HTMLButtonElement>, index: number) {
+    switch (event.key) {
+      case 'ArrowRight':
+        event.preventDefault();
+        moveFocus(index + 1);
+        break;
+      case 'ArrowLeft':
+        event.preventDefault();
+        moveFocus(index - 1);
+        break;
+      case 'ArrowDown':
+        event.preventDefault();
+        moveFocus(index + GRID_COLUMNS);
+        break;
+      case 'ArrowUp':
+        event.preventDefault();
+        moveFocus(index - GRID_COLUMNS);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+      <div aria-live="polite" role="status" className="sr-only">
+        {announcement}
+      </div>
+      <div className="flex flex-col items-center gap-1 text-center">
+        <h1 className="font-display text-2xl font-semibold">Trim to {limit}</h1>
+        <p className="text-sm text-ink-muted">
+          {remainingToCut > 0 ? `Cut ${remainingToCut} more` : `${cards.length - cut.length} kept — ready to continue`}
+        </p>
+      </div>
+      <div role="list" className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {cards.map((card, index) => {
+          const isCut = cut.includes(card.value);
+          return (
+            <button
+              key={card.value}
+              ref={(element) => {
+                itemRefs.current[index] = element;
+              }}
+              type="button"
+              role="listitem"
+              aria-pressed={isCut}
+              aria-label={isCut ? `${card.value}, cut` : card.value}
+              tabIndex={index === focusIndex ? 0 : -1}
+              onFocus={() => setFocusIndex(index)}
+              onKeyDown={(event) => onKeyDown(event, index)}
+              onClick={() => onToggleCut(card.value)}
+              className={`relative flex flex-col items-center gap-2 rounded-card focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${isCut ? 'opacity-50' : ''}`}
+            >
+              <GameCard title={card.value} description={card.description} size="sm" />
+              {isCut ? (
+                <span
+                  aria-hidden="true"
+                  className="absolute right-1 top-1 rounded-control bg-danger px-2 py-1 text-xs text-on-accent"
+                >
+                  ✂
+                </span>
+              ) : null}
+            </button>
+          );
+        })}
+      </div>
+      <Button onClick={onConfirm} disabled={!canConfirm}>
+        Confirm
+      </Button>
+    </main>
+  );
+}

--- a/app/src/engine-ui/rank-board.test.tsx
+++ b/app/src/engine-ui/rank-board.test.tsx
@@ -1,0 +1,133 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { Card } from '@values-cards/shared';
+import { useState } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { RankBoard } from './RankBoard';
+
+// jsdom has no PointerEvent constructor, so @testing-library falls back to a
+// plain Event that drops clientX/clientY/pointerId/isPrimary — dnd-kit's
+// PointerSensor silently bails without them. Polyfill just enough of the
+// real interface for a drag gesture to register.
+if (typeof globalThis.PointerEvent === 'undefined') {
+  class PointerEventPolyfill extends MouseEvent {
+    pointerId: number;
+    isPrimary: boolean;
+    constructor(type: string, params: PointerEventInit = {}) {
+      super(type, params);
+      this.pointerId = params.pointerId ?? 0;
+      this.isPrimary = params.isPrimary ?? true;
+    }
+  }
+  // @ts-expect-error jsdom doesn't implement PointerEvent at all.
+  globalThis.PointerEvent = PointerEventPolyfill;
+}
+
+afterEach(cleanup);
+
+const CARDS: Card[] = [
+  { value: 'Courage', description: 'Acting despite fear' },
+  { value: 'Curiosity', description: 'Seeking to understand' },
+  { value: 'Integrity', description: 'Consistency of values and action' },
+];
+
+const ITEM_HEIGHT = 88;
+
+// dnd-kit measures every sortable item's DOMRect to place the drag preview
+// and resolve collisions. jsdom never lays anything out, so every element
+// reports a zero-size rect by default — stub one that stacks each <li> by
+// its live DOM position, which is exactly what a real vertical list looks
+// like to dnd-kit's collision detection.
+function stackListRects() {
+  const original = Element.prototype.getBoundingClientRect;
+  Element.prototype.getBoundingClientRect = function stubbedRect(this: Element) {
+    const items: Element[] = Array.from(document.querySelectorAll('li'));
+    const li: Element = this.closest('li') ?? this;
+    const index = items.indexOf(li);
+    const top = Math.max(index, 0) * ITEM_HEIGHT;
+    return {
+      x: 0,
+      y: top,
+      top,
+      bottom: top + ITEM_HEIGHT,
+      left: 0,
+      right: 400,
+      width: 400,
+      height: ITEM_HEIGHT,
+      toJSON() {
+        return this;
+      },
+    } as DOMRect;
+  };
+  return () => {
+    Element.prototype.getBoundingClientRect = original;
+  };
+}
+
+function RankBoardFixture({ onConfirm = vi.fn() }: { onConfirm?: () => void }) {
+  const [order, setOrder] = useState(CARDS);
+  return (
+    <RankBoard
+      cards={order}
+      onReorder={(ids) => setOrder(ids.map((id) => order.find((card) => card.value === id) as Card))}
+      onConfirm={onConfirm}
+    />
+  );
+}
+
+describe('RankBoard', () => {
+  let restoreRects: () => void;
+  beforeEach(() => {
+    restoreRects = stackListRects();
+  });
+  afterEach(() => restoreRects());
+
+  it('renders cards in the given order with a 1-based position label', () => {
+    render(<RankBoardFixture />);
+    const items = screen.getAllByRole('listitem');
+    expect(items.map((item) => item.textContent)).toEqual([
+      expect.stringContaining('1. Courage'),
+      expect.stringContaining('2. Curiosity'),
+      expect.stringContaining('3. Integrity'),
+    ]);
+  });
+
+  it('reorders by keyboard sensor alone: space lifts, arrow moves, space drops', async () => {
+    render(<RankBoardFixture />);
+    const handle = screen.getByRole('button', { name: /Reorder Courage/ });
+    handle.focus();
+    await userEvent.keyboard('[Space]');
+    await userEvent.keyboard('[ArrowDown]');
+    await userEvent.keyboard('[Space]');
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]?.textContent).toContain('Curiosity');
+    expect(items[1]?.textContent).toContain('Courage');
+  });
+
+  it('reorders by pointer drag', async () => {
+    render(<RankBoardFixture />);
+    const handle = screen.getByRole('button', { name: /Reorder Courage/ });
+    fireEvent.pointerDown(handle, { pointerId: 1, clientX: 10, clientY: 10 });
+    fireEvent.pointerMove(document, { pointerId: 1, clientX: 10, clientY: 60 });
+    fireEvent.pointerMove(document, { pointerId: 1, clientX: 10, clientY: 130 });
+    fireEvent.pointerUp(document, { pointerId: 1, clientX: 10, clientY: 130 });
+
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]?.textContent).toContain('Curiosity');
+    expect(items[1]?.textContent).toContain('Courage');
+
+    // dnd-kit swallows the synthetic click that trails a pointer drag by
+    // stopping its propagation for 50ms after pointerup (browsers fire that
+    // click regardless of drag) — let that window pass so it doesn't eat a
+    // later test's real click in this same jsdom document.
+    await new Promise((resolve) => setTimeout(resolve, 60));
+  });
+
+  it('final order lands with Confirm', () => {
+    const onConfirm = vi.fn();
+    render(<RankBoardFixture onConfirm={onConfirm} />);
+    fireEvent.click(screen.getByRole('button', { name: 'Confirm order' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+});

--- a/app/src/engine-ui/trim-grid.test.tsx
+++ b/app/src/engine-ui/trim-grid.test.tsx
@@ -1,0 +1,89 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactElement } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { MotionProvider } from '../theme/motion';
+import { TrimGrid } from './TrimGrid';
+
+afterEach(cleanup);
+
+const CARDS = [
+  { value: 'Courage', description: 'Acting despite fear' },
+  { value: 'Curiosity', description: 'Seeking to understand' },
+  { value: 'Integrity', description: 'Consistency of values and action' },
+];
+
+function renderGrid(element: ReactElement) {
+  const result = render(<MotionProvider>{element}</MotionProvider>);
+  return {
+    ...result,
+    rerender: (next: ReactElement) => result.rerender(<MotionProvider>{next}</MotionProvider>),
+  };
+}
+
+describe('TrimGrid', () => {
+  it('counts down to the keep-count', () => {
+    renderGrid(<TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByText('Cut 2 more')).toBeDefined();
+  });
+
+  it('tapping a card toggles it cut', async () => {
+    const onToggleCut = vi.fn();
+    renderGrid(<TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={onToggleCut} onConfirm={vi.fn()} />);
+    await userEvent.click(screen.getByRole('listitem', { name: 'Courage' }));
+    expect(onToggleCut).toHaveBeenCalledWith('Courage');
+  });
+
+  it('shows the cut badge and dims a cut card, and re-counts the header', () => {
+    renderGrid(<TrimGrid cards={CARDS} cut={['Courage']} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByText('Cut 1 more')).toBeDefined();
+    const cutItem = screen.getByRole('listitem', { name: 'Courage, cut' });
+    expect(cutItem.getAttribute('aria-pressed')).toBe('true');
+    expect(cutItem.className).toContain('opacity-50');
+  });
+
+  it('Confirm is disabled while over the limit and enabled at/under it (invariant 3)', () => {
+    const { rerender } = renderGrid(
+      <TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />,
+    );
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveProperty('disabled', true);
+
+    rerender(<TrimGrid cards={CARDS} cut={['Courage', 'Curiosity']} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Confirm' })).toHaveProperty('disabled', false);
+  });
+
+  it('Confirm calls onConfirm', async () => {
+    const onConfirm = vi.fn();
+    renderGrid(
+      <TrimGrid cards={CARDS} cut={['Courage', 'Curiosity']} limit={1} onToggleCut={vi.fn()} onConfirm={onConfirm} />,
+    );
+    await userEvent.click(screen.getByRole('button', { name: 'Confirm' }));
+    expect(onConfirm).toHaveBeenCalledTimes(1);
+  });
+
+  it('is fully keyboard operable: arrow keys move the roving tab stop, Enter toggles cut', async () => {
+    const onToggleCut = vi.fn();
+    renderGrid(<TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={onToggleCut} onConfirm={vi.fn()} />);
+    const items = screen.getAllByRole('listitem');
+    expect(items[0]?.tabIndex).toBe(0);
+    expect(items[1]?.tabIndex).toBe(-1);
+
+    (items[0] as HTMLElement).focus();
+    await userEvent.keyboard('{ArrowRight}');
+    expect(document.activeElement).toBe(items[1]);
+
+    await userEvent.keyboard('{Enter}');
+    expect(onToggleCut).toHaveBeenCalledWith('Curiosity');
+  });
+
+  it('announces cut and restore for screen readers', () => {
+    const { rerender } = renderGrid(
+      <TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />,
+    );
+    rerender(<TrimGrid cards={CARDS} cut={['Courage']} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole('status').textContent).toBe('Courage cut');
+
+    rerender(<TrimGrid cards={CARDS} cut={[]} limit={1} onToggleCut={vi.fn()} onConfirm={vi.fn()} />);
+    expect(screen.getByRole('status').textContent).toBe('Courage restored');
+  });
+});

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -1,7 +1,11 @@
 import { useMemo } from 'react';
-import { GameConfigSchema, type GameConfig } from '@values-cards/shared';
+import { GameConfigSchema, type Card, type GameConfig } from '@values-cards/shared';
+import { Button } from '../components/Button';
+import { GameCard } from '../components/GameCard';
+import { RankBoard } from '../engine-ui/RankBoard';
 import { SortRound } from '../engine-ui/SortRound';
-import { createSortStore } from '../stores/createSortStore';
+import { TrimGrid } from '../engine-ui/TrimGrid';
+import { createSortStore, getPhase } from '../stores/createSortStore';
 
 // Placeholder session identity until 01.2 (client session layer) wires a
 // real join flow. The sort loop itself is fully local and config-driven —
@@ -10,26 +14,33 @@ import { createSortStore } from '../stores/createSortStore';
 const SESSION_CODE = 'DEMO01';
 const PARTICIPANT_ID_KEY = 'vc:demo:participantId';
 
+// dev-12 (decks/decks/dev-12.json), two rounds: 12 -> keep 8 -> keep 3
+// (ranked) — this is also the fixture the 01.4 acceptance E2E (solo-journey,
+// round-flow-refresh) drives, so trim and rank are always reachable from
+// this one demo route.
 const DEMO_CONFIG: GameConfig = GameConfigSchema.parse({
   title: 'Demo',
   deck: {
-    name: 'Demo deck',
+    name: 'Dev 12',
     cards: [
-      { value: 'Courage', description: 'Acting despite fear' },
-      { value: 'Curiosity', description: 'Seeking to understand' },
-      { value: 'Integrity', description: 'Consistency of values and action' },
-      { value: 'Trust', description: 'Confidence in others’ intentions' },
-      { value: 'Growth', description: 'Committing to improve' },
-      { value: 'Empathy', description: 'Understanding others’ experience' },
-      { value: 'Discipline', description: 'Doing what matters most' },
-      { value: 'Humility', description: 'Openness to being wrong' },
-      { value: 'Resilience', description: 'Recovering from setbacks' },
-      { value: 'Fairness', description: 'Treating others equitably' },
-      { value: 'Creativity', description: 'Generating novel ideas' },
-      { value: 'Gratitude', description: 'Appreciating what is given' },
+      { value: 'Caffeine', description: 'The fundamental belief that productivity is directly proportional to coffee consumption' },
+      { value: 'Snacks', description: 'Commitment to maintaining strategic reserves of treats for optimal team morale' },
+      { value: 'Muting', description: 'The discipline to silence oneself before dogs, children, or doorbells interrupt meetings' },
+      { value: 'Restraint', description: 'The wisdom to resist reply-all when someone microwaves fish in the office' },
+      { value: 'Efficiency', description: 'The courage to end meetings that have veered into discussing weekend plans' },
+      { value: 'Flexibility', description: 'The art of interpreting deadlines as gentle suggestions rather than fixed points' },
+      { value: 'Lunch', description: 'The sacred practice of stepping away from one’s desk for actual nourishment' },
+      { value: 'Emojis', description: 'The ability to convey professionalism while using the perfect amount of 👍 and 😊' },
+      { value: 'Parking', description: 'The mystical force that guides one to spaces near the entrance, always' },
+      { value: 'Friday', description: 'The superhuman strength to maintain focus despite the weekend’s gravitational pull' },
+      { value: 'Spreadsheets', description: 'Finding enlightenment through pivot tables and conditional formatting' },
+      { value: 'Cake', description: 'The moral duty to ensure equitable distribution of celebration desserts' },
     ],
   },
-  rounds: [{ name: 'Round 1', keep: 6, rank: false }],
+  rounds: [
+    { name: 'Round 1', keep: 8, rank: false },
+    { name: 'Round 2', keep: 3, rank: true },
+  ],
   theme: { variant: 'default' },
   facilitated: false,
 });
@@ -42,11 +53,91 @@ function getDemoParticipantId(): string {
   return id;
 }
 
+function cardsInOrder(ids: string[], byId: Map<string, Card>): Card[] {
+  return ids.map((id) => byId.get(id)).filter((card): card is Card => !!card);
+}
+
+/**
+ * Everything between "queue empty" and "final result" (01.4), driven by the
+ * store's derived phase — trim and rank are conditional phases of this one
+ * flow, never separate pages/routes.
+ */
 export function Sort() {
   const useSortStore = useMemo(() => {
     const participantId = getDemoParticipantId();
     return createSortStore(SESSION_CODE, participantId, DEMO_CONFIG);
   }, []);
 
-  return <SortRound config={DEMO_CONFIG} useSortStore={useSortStore} />;
+  const state = useSortStore();
+  const phase = getPhase(state, DEMO_CONFIG);
+  const byId = useMemo(() => new Map(DEMO_CONFIG.deck.cards.map((card) => [card.value, card])), []);
+
+  if (phase === 'sort') {
+    return <SortRound config={DEMO_CONFIG} useSortStore={useSortStore} />;
+  }
+
+  if (phase === 'round-complete') {
+    const roundCfg = DEMO_CONFIG.rounds[state.round - 1];
+    const setAside = state.totalDiscarded + state.discarded.length;
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-center text-ink">
+        <h1 className="font-display text-2xl font-semibold">{roundCfg?.name} complete</h1>
+        <p className="text-ink-muted">
+          {state.kept.length} kept · {setAside} set aside
+        </p>
+        <Button onClick={() => useSortStore.getState().continueRound()}>Continue</Button>
+      </main>
+    );
+  }
+
+  if (phase === 'trim') {
+    const roundCfg = DEMO_CONFIG.rounds[state.round - 1];
+    const limit = typeof roundCfg?.keep === 'number' ? roundCfg.keep : 0;
+    return (
+      <TrimGrid
+        cards={cardsInOrder(state.kept, byId)}
+        cut={state.cut}
+        limit={limit}
+        onToggleCut={(cardId) => useSortStore.getState().toggleCut(cardId)}
+        onConfirm={() => useSortStore.getState().confirmTrim()}
+      />
+    );
+  }
+
+  if (phase === 'rank') {
+    return (
+      <RankBoard
+        cards={cardsInOrder(state.ranking ?? state.kept, byId)}
+        onReorder={(order) => useSortStore.getState().setRanking(order)}
+        onConfirm={() => useSortStore.getState().confirmRank()}
+      />
+    );
+  }
+
+  // result — local-only plaque preview; reveal (02.2), wall (02.3) and
+  // export (04.1) build on this later.
+  const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
+  const isRanked = DEMO_CONFIG.rounds[DEMO_CONFIG.rounds.length - 1]?.rank === true;
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+      <h1 className="font-display text-2xl font-semibold">{DEMO_CONFIG.title}</h1>
+      <p className="text-ink-muted">Your final cards</p>
+      <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {finalCards.map((card, index) => (
+          <li key={card.value} className="flex flex-col items-center gap-2">
+            {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
+            <GameCard title={card.value} description={card.description} size="md" />
+          </li>
+        ))}
+      </ol>
+      <div className="flex gap-4">
+        <Button variant="secondary" disabled title="Coming soon">
+          Reveal
+        </Button>
+        <Button variant="secondary" disabled title="Coming soon">
+          Download
+        </Button>
+      </div>
+    </main>
+  );
 }

--- a/app/src/stores/createSortStore.ts
+++ b/app/src/stores/createSortStore.ts
@@ -1,6 +1,6 @@
 import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
-import { shuffle, type GameConfig } from '@values-cards/shared';
+import { canFinishRound, nextRound, shuffle, type GameConfig } from '@values-cards/shared';
 
 /**
  * Local per-participant sort state (architecture §4.2). Card IDs are the
@@ -19,8 +19,37 @@ export interface SortState {
   queue: string[];
   kept: string[];
   discarded: string[];
-  lastAction?: SortAction;
+  /** Cards discarded in *previous* rounds — the current round's `discarded` is added in on `continueRound` (01.4). */
+  totalDiscarded: number;
+  /** Kept cards marked to cut in TrimGrid, pending `confirmTrim` (01.4). */
+  cut: string[];
+  /** Final-round order from RankBoard; locked in once `confirmRank` runs (01.4). */
   ranking?: string[];
+  rankConfirmed: boolean;
+  lastAction?: SortAction;
+}
+
+export type SortPhase = 'sort' | 'round-complete' | 'trim' | 'rank' | 'result';
+
+/**
+ * Derives where the flow is from state + config alone — no separate phase
+ * field to fall out of sync on refresh (round.ts's `canFinishRound` is the
+ * single source of truth for round completion; the same 40->8->3 shape or
+ * any other config drives this without per-round special-casing).
+ */
+export function getPhase(
+  state: Pick<SortState, 'round' | 'queue' | 'kept' | 'rankConfirmed'>,
+  config: GameConfig,
+): SortPhase {
+  const roundCfg = config.rounds[state.round - 1];
+  if (!roundCfg) return 'result';
+  const status = canFinishRound(state, roundCfg);
+  if ('incomplete' in status) return 'sort';
+  if ('needTrim' in status) return 'trim';
+  const isLastRound = state.round >= config.rounds.length;
+  if (!isLastRound) return 'round-complete';
+  if (roundCfg.rank && !state.rankConfirmed) return 'rank';
+  return 'result';
 }
 
 export interface SortStore extends SortState {
@@ -28,6 +57,15 @@ export interface SortStore extends SortState {
   discard: (cardId: string) => void;
   undo: () => void;
   demote: (cardId: string) => void;
+  /** Toggle a kept card as cut in TrimGrid. */
+  toggleCut: (cardId: string) => void;
+  /** Moves cut cards into `discarded`. No-op unless cutting enough clears the keep-count (invariant 3). */
+  confirmTrim: () => void;
+  /** Advances to the next round via the shared engine. No-op unless the round can actually finish. */
+  continueRound: () => void;
+  setRanking: (order: string[]) => void;
+  /** Locks in the final order (defaulting to kept order if the board was never touched). */
+  confirmRank: () => void;
 }
 
 function initialQueue(config: GameConfig, participantId: string, round: number): string[] {
@@ -50,6 +88,9 @@ export function createSortStore(sessionCode: string, participantId: string, conf
         queue: initialQueue(config, participantId, 1),
         kept: [],
         discarded: [],
+        totalDiscarded: 0,
+        cut: [],
+        rankConfirmed: false,
 
         keep: (cardId) => {
           const state = get();
@@ -106,6 +147,67 @@ export function createSortStore(sessionCode: string, participantId: string, conf
             kept.splice(action.fromIndex ?? kept.length, 0, action.cardId);
             set({ queue, kept, lastAction: undefined });
           }
+        },
+
+        toggleCut: (cardId) => {
+          const state = get();
+          if (!state.kept.includes(cardId)) return;
+          set({
+            cut: state.cut.includes(cardId)
+              ? state.cut.filter((id) => id !== cardId)
+              : [...state.cut, cardId],
+          });
+        },
+
+        confirmTrim: () => {
+          const state = get();
+          const roundCfg = config.rounds[state.round - 1];
+          if (!roundCfg || roundCfg.keep === 'any') return;
+          // Invariant 3 (client half): never drop cards into `discarded` unless
+          // that actually clears the keep-count.
+          if (state.kept.length - state.cut.length > roundCfg.keep) return;
+          set({
+            kept: state.kept.filter((id) => !state.cut.includes(id)),
+            discarded: [...state.discarded, ...state.cut],
+            cut: [],
+          });
+        },
+
+        continueRound: () => {
+          const state = get();
+          const roundCfg = config.rounds[state.round - 1];
+          if (!roundCfg || state.round >= config.rounds.length) return;
+          const status = canFinishRound(state, roundCfg);
+          if (!('ok' in status)) return;
+          const next = nextRound(
+            {
+              participantId,
+              round: state.round,
+              queue: state.queue,
+              kept: state.kept,
+              discarded: state.discarded,
+              totalDiscarded: state.totalDiscarded,
+            },
+            config,
+          );
+          set({
+            round: next.round,
+            queue: next.queue,
+            kept: next.kept,
+            discarded: next.discarded,
+            totalDiscarded: next.totalDiscarded,
+            cut: [],
+            ranking: undefined,
+            rankConfirmed: false,
+            lastAction: undefined,
+          });
+        },
+
+        setRanking: (order) => set({ ranking: order }),
+
+        confirmRank: () => {
+          const state = get();
+          set({ ranking: state.ranking ?? state.kept, rankConfirmed: true });
         },
       }),
       { name: `vc:${sessionCode}:${participantId}:sort` },

--- a/app/src/stores/round-flow.test.ts
+++ b/app/src/stores/round-flow.test.ts
@@ -1,0 +1,172 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import type { GameConfig } from '@values-cards/shared';
+import { createSortStore, getPhase } from './createSortStore';
+
+function twoRoundConfig(): GameConfig {
+  return {
+    title: 'Test',
+    deck: {
+      name: 'Deck',
+      cards: Array.from({ length: 5 }, (_, i) => ({ value: `Card ${i}`, description: `Desc ${i}` })),
+    },
+    rounds: [
+      { name: 'Round 1', keep: 3, rank: false },
+      { name: 'Round 2', keep: 2, rank: true },
+    ],
+    theme: { variant: 'default' },
+    facilitated: false,
+  };
+}
+
+/** Keeps the first `keepCount` cards in the queue and discards the rest, so the queue empties. */
+function sortRound(store: ReturnType<typeof createSortStore>, keepCount: number) {
+  let kept = 0;
+  while (store.getState().queue.length > 0) {
+    const head = store.getState().queue[0] as string;
+    if (kept < keepCount) {
+      store.getState().keep(head);
+      kept++;
+    } else {
+      store.getState().discard(head);
+    }
+  }
+}
+
+/** Keeps every remaining card in the queue (used to deliberately over-keep for trim tests). */
+function keepAll(store: ReturnType<typeof createSortStore>, count: number) {
+  for (let i = 0; i < count; i++) {
+    const head = store.getState().queue[0];
+    if (head === undefined) return;
+    store.getState().keep(head);
+  }
+}
+
+beforeEach(() => {
+  localStorage.clear();
+});
+
+describe('round flow wiring', () => {
+  it('at/under keep-count with a next round goes straight to round-complete', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 3); // exactly the round-1 keep count, queue now empty
+    expect(getPhase(store.getState(), config)).toBe('round-complete');
+  });
+
+  it('keeping fewer than the keep-count is allowed — still goes straight to round-complete', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 1); // keep 1, discard the other 4 — well under the round-1 keep-count of 3
+    expect(store.getState().kept).toHaveLength(1);
+    expect(getPhase(store.getState(), config)).toBe('round-complete');
+  });
+
+  it('over the keep-count needs a trim', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    keepAll(store, 5); // deck has 5 cards, round 1 keeps only 3
+    expect(store.getState().kept).toHaveLength(5);
+    expect(getPhase(store.getState(), config)).toBe('trim');
+  });
+
+  it('confirmTrim is a no-op until enough cards are cut (invariant 3)', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    keepAll(store, 5);
+    const [a] = store.getState().kept;
+    store.getState().toggleCut(a as string); // only 1 of the 2 needed cuts
+    store.getState().confirmTrim();
+    expect(store.getState().kept).toHaveLength(5); // unchanged — still over limit
+    expect(getPhase(store.getState(), config)).toBe('trim');
+  });
+
+  it('confirmTrim cuts down to the keep-count and accumulates the discard counter', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    keepAll(store, 5);
+    const [a, b] = store.getState().kept;
+    store.getState().toggleCut(a as string);
+    store.getState().toggleCut(b as string);
+    store.getState().confirmTrim();
+    const state = store.getState();
+    expect(state.kept).toHaveLength(3);
+    expect(state.discarded).toEqual(expect.arrayContaining([a, b]));
+    expect(getPhase(state, config)).toBe('round-complete');
+  });
+
+  it('continueRound refuses to advance while kept is still over the keep-count (invariant 3)', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    keepAll(store, 5); // needs a trim, never confirmed
+    store.getState().continueRound();
+    expect(store.getState().round).toBe(1); // did not advance
+    expect(store.getState().kept).toHaveLength(5);
+  });
+
+  it('continueRound advances via the shared engine: kept becomes the reshuffled next-round queue', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 3);
+    const keptGoingIn = store.getState().kept;
+    store.getState().continueRound();
+    const state = store.getState();
+    expect(state.round).toBe(2);
+    expect(state.kept).toEqual([]);
+    expect(state.discarded).toEqual([]);
+    expect(new Set(state.queue)).toEqual(new Set(keptGoingIn));
+    expect(getPhase(state, config)).toBe('sort');
+  });
+
+  it('discard counter accumulates across rounds', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    // Round 1: discard 2, keep 3.
+    store.getState().discard(store.getState().queue[0] as string);
+    store.getState().discard(store.getState().queue[0] as string);
+    keepAll(store, 3);
+    expect(store.getState().totalDiscarded).toBe(0); // not yet rolled up
+    store.getState().continueRound();
+    expect(store.getState().totalDiscarded).toBe(2);
+
+    // Round 2 (final, keep 2 of 3): discard 1.
+    store.getState().discard(store.getState().queue[0] as string);
+    keepAll(store, 2);
+    expect(getPhase(store.getState(), config)).toBe('rank'); // final round, rank: true
+  });
+
+  it('final round without rank goes straight to result once at/under the keep-count', () => {
+    const config: GameConfig = {
+      ...twoRoundConfig(),
+      rounds: [{ name: 'Only round', keep: 3, rank: false }],
+    };
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 3);
+    expect(getPhase(store.getState(), config)).toBe('result');
+  });
+
+  it('confirmRank locks in the ranking (defaulting to kept order) and unlocks the result phase', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 3);
+    store.getState().continueRound(); // into round 2 (final, rank: true)
+    sortRound(store, 2);
+    expect(getPhase(store.getState(), config)).toBe('rank');
+    const keptOrder = store.getState().kept;
+    store.getState().confirmRank();
+    const state = store.getState();
+    expect(state.ranking).toEqual(keptOrder);
+    expect(getPhase(state, config)).toBe('result');
+  });
+
+  it('setRanking is respected by confirmRank instead of the default kept order', () => {
+    const config = twoRoundConfig();
+    const store = createSortStore('CODE1', 'p1', config);
+    sortRound(store, 3);
+    store.getState().continueRound();
+    sortRound(store, 2);
+    const reversed = [...store.getState().kept].reverse();
+    store.getState().setRanking(reversed);
+    store.getState().confirmRank();
+    expect(store.getState().ranking).toEqual(reversed);
+  });
+});

--- a/e2e/round-flow-refresh.spec.ts
+++ b/e2e/round-flow-refresh.spec.ts
@@ -1,0 +1,125 @@
+import { expect, type Locator, type Page, test } from '@playwright/test';
+
+async function cardNameOf(item: Locator): Promise<string> {
+  const label = await item.locator('p').first().textContent();
+  return (label ?? '').replace(/^\d+\.\s*/, '');
+}
+
+async function orderOf(items: Locator): Promise<string[]> {
+  const count = await items.count();
+  const names: string[] = [];
+  for (let i = 0; i < count; i++) {
+    names.push(await cardNameOf(items.nth(i)));
+  }
+  return names;
+}
+
+/**
+ * Drags the first item down past the second with the pointer. The keyboard
+ * sensor (space to lift, arrows to move, space to drop) is exercised by
+ * `rank-board.test.tsx` and the keyboard-only solo journey instead — under
+ * this suite's real-browser layout, ArrowDown's rect-based jump is prone to
+ * losing a race with dnd-kit's ResizeObserver measurement (or scrolling the
+ * page instead of the item, per dnd-kit's own auto-scroll handling), which a
+ * pointer drag with real, on-screen coordinates doesn't hit.
+ */
+async function reorderFirstItemDown(page: Page, items: Locator): Promise<string[]> {
+  const before = await orderOf(items);
+  const handle = items.first().getByRole('button');
+  const box = await handle.boundingBox();
+  if (!box) throw new Error('rank handle not found');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  // dnd-kit measures every droppable's rect via ResizeObserver right as the
+  // drag starts — give that a moment or the move can compute against stale
+  // rects.
+  await page.waitForTimeout(150);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height * 2, { steps: 10 });
+  await page.mouse.up();
+  const after = await orderOf(items);
+  if (after.join('|') === before.join('|')) {
+    throw new Error('pointer reorder never changed the rank order');
+  }
+  return after;
+}
+
+/** Clicks Keep/Discard `count` times, waiting for each card's exit animation
+ * to settle (the "N left" counter to decrement) before the next click. */
+async function resolveQueue(page: Page, count: number, keep: (index: number) => boolean) {
+  for (let i = 0; i < count; i++) {
+    const remainingBefore = count - i;
+    await page.getByRole('button', { name: keep(i) ? /^Keep / : /^Discard / }).click();
+    if (remainingBefore - 1 > 0) {
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
+    }
+  }
+}
+
+test('refresh during TrimGrid preserves the exact cut selection (invariant 4)', async ({ page }) => {
+  await page.goto('/sort');
+  await expect(page.getByText('12 left')).toBeVisible();
+
+  // Keep every card — 12 kept is over round 1's keep-count of 8.
+  await resolveQueue(page, 12, () => true);
+  await expect(page.getByRole('heading', { name: 'Trim to 8' })).toBeVisible({ timeout: 3000 });
+
+  const items = page.getByRole('listitem');
+  const firstName = await items.first().getAttribute('aria-label');
+  await items.first().click();
+  await expect(page.getByText('Cut 3 more')).toBeVisible();
+
+  await page.reload();
+
+  await expect(page.getByRole('heading', { name: 'Trim to 8' })).toBeVisible();
+  await expect(page.getByText('Cut 3 more')).toBeVisible();
+  await expect(page.getByRole('listitem', { name: `${firstName}, cut` })).toBeVisible();
+});
+
+test('refresh during RankBoard preserves the exact rank order (invariant 4)', async ({ page }) => {
+  await page.goto('/sort');
+  await expect(page.getByText('12 left')).toBeVisible();
+
+  // Round 1: keep exactly 8, discard 4 — at the keep-count, straight to
+  // round-complete with no trim needed.
+  await resolveQueue(page, 12, (i) => i < 8);
+  await expect(page.getByRole('heading', { name: 'Round 1 complete' })).toBeVisible({ timeout: 3000 });
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  await expect(page.getByText('8 left')).toBeVisible();
+  // Round 2 (final, ranked): keep exactly 3, discard 5.
+  await resolveQueue(page, 8, (i) => i < 3);
+  await expect(page.getByRole('heading', { name: 'Rank your final cards' })).toBeVisible({ timeout: 3000 });
+
+  const items = page.getByRole('listitem');
+  const reordered = await reorderFirstItemDown(page, items);
+
+  await page.reload();
+
+  await expect(page.getByRole('heading', { name: 'Rank your final cards' })).toBeVisible();
+  await expect.poll(() => orderOf(page.getByRole('listitem'))).toEqual(reordered);
+
+  // Ranking round-trips onto the result screen too, including through a
+  // second refresh once it's the terminal state (the result screen's cards
+  // aren't numbered paragraphs like RankBoard's, so read the GameCard title).
+  //
+  // dnd-kit stops propagation on the synthetic click that trails a pointer
+  // drag for 50ms after pointerup (browsers fire that click regardless of
+  // drag) — past that window before clicking Confirm order for real.
+  await page.waitForTimeout(60);
+  await page.getByRole('button', { name: 'Confirm order' }).click();
+  await expect(page.getByRole('heading', { name: 'Demo' })).toBeVisible({ timeout: 3000 });
+  const resultOrder = async () => {
+    const cards = page.getByRole('listitem');
+    const count = await cards.count();
+    const names: string[] = [];
+    for (let i = 0; i < count; i++) {
+      names.push((await cards.nth(i).locator('h3').first().textContent()) ?? '');
+    }
+    return names;
+  };
+  await expect.poll(resultOrder).toEqual(reordered);
+
+  await page.reload();
+  await expect(page.getByRole('heading', { name: 'Demo' })).toBeVisible();
+  await expect.poll(resultOrder).toEqual(reordered);
+});

--- a/e2e/solo-journey.spec.ts
+++ b/e2e/solo-journey.spec.ts
@@ -1,0 +1,124 @@
+import { expect, type Page, test } from '@playwright/test';
+
+// dev-12 deck, rounds 12 -> keep 8 -> keep 3 (ranked) — app/src/routes/Sort.tsx's demo config.
+
+/** dnd-kit measures every droppable's rect via ResizeObserver right as a
+ * drag starts — that lands a frame or two after pointerdown, so the very
+ * next move can otherwise compute against stale rects. A wall-clock wait is
+ * flaky under load; waiting for real frames to elapse isn't. */
+async function waitForLayoutMeasurement(page: Page) {
+  for (let i = 0; i < 5; i++) {
+    await page.evaluate(() => new Promise<void>((resolve) => requestAnimationFrame(() => resolve())));
+  }
+}
+
+test('solo journey (pointer): sort -> trim -> next round -> rank -> result', async ({ page }) => {
+  await page.goto('/sort');
+  await expect(page.getByText('12 left')).toBeVisible();
+
+  // Round 1 (keep 8 of 12): deliberately over-keep 10, discard 2, to force TrimGrid.
+  for (let i = 0; i < 12; i++) {
+    const remainingBefore = 12 - i;
+    await page.getByRole('button', { name: i < 10 ? /^Keep / : /^Discard / }).click();
+    if (remainingBefore - 1 > 0) {
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
+    }
+  }
+  await expect(page.getByRole('heading', { name: 'Trim to 8' })).toBeVisible({ timeout: 3000 });
+
+  // Cut 2 to clear the keep-count.
+  const trimItems = page.getByRole('listitem');
+  await trimItems.nth(0).click();
+  await trimItems.nth(1).click();
+  const confirmTrim = page.getByRole('button', { name: 'Confirm' });
+  await expect(confirmTrim).toBeEnabled();
+  await confirmTrim.click();
+
+  await expect(page.getByRole('heading', { name: 'Round 1 complete' })).toBeVisible({ timeout: 3000 });
+  await page.getByRole('button', { name: 'Continue' }).click();
+
+  // Round 2 (final, ranked, keep 3 of 8).
+  await expect(page.getByText('8 left')).toBeVisible();
+  for (let i = 0; i < 8; i++) {
+    const remainingBefore = 8 - i;
+    await page.getByRole('button', { name: i < 3 ? /^Keep / : /^Discard / }).click();
+    if (remainingBefore - 1 > 0) {
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
+    }
+  }
+  await expect(page.getByRole('heading', { name: 'Rank your final cards' })).toBeVisible({ timeout: 3000 });
+
+  // Drag the first handle down past the second item.
+  const handle = page.getByRole('listitem').first().getByRole('button');
+  const box = await handle.boundingBox();
+  if (!box) throw new Error('rank handle not found');
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height / 2);
+  await page.mouse.down();
+  await waitForLayoutMeasurement(page);
+  await page.mouse.move(box.x + box.width / 2, box.y + box.height + 40, { steps: 10 });
+  await page.mouse.up();
+  // dnd-kit stops propagation on the synthetic click that trails a pointer
+  // drag for 50ms after pointerup (browsers fire that click regardless of
+  // drag) — past that window before clicking Confirm order for real.
+  await page.waitForTimeout(60);
+
+  await page.getByRole('button', { name: 'Confirm order' }).click();
+
+  await expect(page.getByRole('heading', { name: 'Demo' })).toBeVisible({ timeout: 3000 });
+  await expect(page.getByRole('listitem')).toHaveCount(3);
+  await expect(page.getByRole('button', { name: 'Reveal' })).toBeDisabled();
+  await expect(page.getByRole('button', { name: 'Download' })).toBeDisabled();
+});
+
+test('solo journey (keyboard-only): sort -> trim -> next round -> rank -> result', async ({ page }) => {
+  await page.goto('/sort');
+  await expect(page.getByText('12 left')).toBeVisible();
+
+  // Round 1: over-keep 10 of 12 via keyboard alone.
+  for (let i = 0; i < 12; i++) {
+    const remainingBefore = 12 - i;
+    await page.keyboard.press(i < 10 ? 'ArrowRight' : 'ArrowLeft');
+    if (remainingBefore - 1 > 0) {
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
+    }
+  }
+  await expect(page.getByRole('heading', { name: 'Trim to 8' })).toBeVisible({ timeout: 3000 });
+
+  // Roving-tabindex grid: Tab onto it, Enter cuts, ArrowRight moves the tab stop.
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Enter');
+  await page.keyboard.press('ArrowRight');
+  await page.keyboard.press('Enter');
+  await expect(page.getByRole('button', { name: 'Confirm' })).toBeEnabled();
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('heading', { name: 'Round 1 complete' })).toBeVisible({ timeout: 3000 });
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Enter');
+
+  // Round 2 (final, ranked, keep 3 of 8) via keyboard alone.
+  await expect(page.getByText('8 left')).toBeVisible();
+  for (let i = 0; i < 8; i++) {
+    const remainingBefore = 8 - i;
+    await page.keyboard.press(i < 3 ? 'ArrowRight' : 'ArrowLeft');
+    if (remainingBefore - 1 > 0) {
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
+    }
+  }
+  await expect(page.getByRole('heading', { name: 'Rank your final cards' })).toBeVisible({ timeout: 3000 });
+
+  // Tab past the 3 sortable handles to reach Confirm order — the keyboard
+  // sensor's reordering (space to lift, arrows to move, space to drop) is
+  // unit-tested in rank-board.test.tsx; this journey only needs to prove
+  // the whole flow is reachable without a pointer.
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await page.keyboard.press('Tab');
+  await expect(page.getByRole('button', { name: 'Confirm order' })).toBeFocused();
+  await page.keyboard.press('Enter');
+
+  await expect(page.getByRole('heading', { name: 'Demo' })).toBeVisible({ timeout: 3000 });
+  await expect(page.getByRole('listitem')).toHaveCount(3);
+});

--- a/e2e/sort-kept-tray.spec.ts
+++ b/e2e/sort-kept-tray.spec.ts
@@ -5,15 +5,15 @@ test('kept tray expands, shows kept cards, and demotes one back to the queue', a
   await expect(page.getByText('12 left')).toBeVisible();
 
   await page.getByRole('button', { name: /^Keep / }).click();
-  await expect(page.getByRole('button', { name: 'Kept cards: 1 / 6 kept' })).toBeVisible({ timeout: 3000 });
+  await expect(page.getByRole('button', { name: 'Kept cards: 1 / 8 kept' })).toBeVisible({ timeout: 3000 });
   await page.getByRole('button', { name: /^Keep / }).click();
-  await expect(page.getByRole('button', { name: 'Kept cards: 2 / 6 kept' })).toBeVisible({ timeout: 3000 });
+  await expect(page.getByRole('button', { name: 'Kept cards: 2 / 8 kept' })).toBeVisible({ timeout: 3000 });
 
-  await page.getByRole('button', { name: 'Kept cards: 2 / 6 kept' }).click();
+  await page.getByRole('button', { name: 'Kept cards: 2 / 8 kept' }).click();
   const demoteButtons = page.getByRole('button', { name: 'Demote' });
   await expect(demoteButtons).toHaveCount(2);
 
   await demoteButtons.first().click();
-  await expect(page.getByRole('button', { name: 'Kept cards: 1 / 6 kept' })).toBeVisible();
+  await expect(page.getByRole('button', { name: 'Kept cards: 1 / 8 kept' })).toBeVisible();
   await expect(page.getByText('11 left')).toBeVisible(); // demoted card returned to the queue
 });

--- a/e2e/sort-keyboard.spec.ts
+++ b/e2e/sort-keyboard.spec.ts
@@ -10,7 +10,9 @@ test('completes a 12-card round using only the keyboard', async ({ page }) => {
     if (remainingBefore - 1 > 0) {
       await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
     } else {
-      await expect(page.getByText('Round complete')).toBeVisible({ timeout: 3000 });
+      // 6 keeps / 6 discards, at/under round 1's keep-count of 8 — straight
+      // to the round-complete interstitial (01.4), no trim needed.
+      await expect(page.getByRole('heading', { name: 'Round 1 complete' })).toBeVisible({ timeout: 3000 });
     }
   }
 });

--- a/e2e/sort-privacy.spec.ts
+++ b/e2e/sort-privacy.spec.ts
@@ -3,30 +3,30 @@ import { expect, test } from '@playwright/test';
 // Every value/description string in the demo deck (app/src/routes/Sort.tsx) —
 // none of these may ever appear in a network frame before reveal (02.2).
 const CARD_STRINGS = [
-  'Courage',
-  'Acting despite fear',
-  'Curiosity',
-  'Seeking to understand',
-  'Integrity',
-  'Consistency of values and action',
-  'Trust',
-  'Confidence in others’ intentions',
-  'Growth',
-  'Committing to improve',
-  'Empathy',
-  'Understanding others’ experience',
-  'Discipline',
-  'Doing what matters most',
-  'Humility',
-  'Openness to being wrong',
-  'Resilience',
-  'Recovering from setbacks',
-  'Fairness',
-  'Treating others equitably',
-  'Creativity',
-  'Generating novel ideas',
-  'Gratitude',
-  'Appreciating what is given',
+  'Caffeine',
+  'The fundamental belief that productivity is directly proportional to coffee consumption',
+  'Snacks',
+  'Commitment to maintaining strategic reserves of treats for optimal team morale',
+  'Muting',
+  'The discipline to silence oneself before dogs, children, or doorbells interrupt meetings',
+  'Restraint',
+  'The wisdom to resist reply-all when someone microwaves fish in the office',
+  'Efficiency',
+  'The courage to end meetings that have veered into discussing weekend plans',
+  'Flexibility',
+  'The art of interpreting deadlines as gentle suggestions rather than fixed points',
+  'Lunch',
+  'The sacred practice of stepping away from one’s desk for actual nourishment',
+  'Emojis',
+  'The ability to convey professionalism while using the perfect amount of 👍 and 😊',
+  'Parking',
+  'The mystical force that guides one to spaces near the entrance, always',
+  'Friday',
+  'The superhuman strength to maintain focus despite the weekend’s gravitational pull',
+  'Spreadsheets',
+  'Finding enlightenment through pivot tables and conditional formatting',
+  'Cake',
+  'The moral duty to ensure equitable distribution of celebration desserts',
 ];
 
 test('sorting a full round emits no card data over the network (invariant 1)', async ({ page }) => {
@@ -45,7 +45,8 @@ test('sorting a full round emits no card data over the network (invariant 1)', a
     if (remainingBefore - 1 > 0) {
       await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
     } else {
-      await expect(page.getByText('Round complete')).toBeVisible({ timeout: 3000 });
+      // Keeping all 12 is over round 1's keep-count of 8 — lands in TrimGrid (01.4).
+      await expect(page.getByRole('heading', { name: 'Trim to 8' })).toBeVisible({ timeout: 3000 });
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,15 @@ importers:
 
   app:
     dependencies:
+      '@dnd-kit/core':
+        specifier: ^6.3.1
+        version: 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/sortable':
+        specifier: ^10.0.0
+        version: 10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities':
+        specifier: ^3.2.2
+        version: 3.2.2(react@19.2.8)
       '@fontsource/fraunces':
         specifier: ^5.3.0
         version: 5.3.0
@@ -315,6 +324,28 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@dnd-kit/accessibility@3.1.1':
+    resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
+    peerDependencies:
+      react: '>=16.8.0'
+
+  '@dnd-kit/core@6.3.1':
+    resolution: {integrity: sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ==}
+    peerDependencies:
+      react: '>=16.8.0'
+      react-dom: '>=16.8.0'
+
+  '@dnd-kit/sortable@10.0.0':
+    resolution: {integrity: sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg==}
+    peerDependencies:
+      '@dnd-kit/core': ^6.3.0
+      react: '>=16.8.0'
+
+  '@dnd-kit/utilities@3.2.2':
+    resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
+    peerDependencies:
+      react: '>=16.8.0'
 
   '@emnapi/core@2.0.0-alpha.3':
     resolution: {integrity: sha512-AZypUeJ/yByuxyS7BlSNRDOMLMlROYtjYdIAuBmJssVz1UJDSeYxLrdizhXCFYhedC5bqd/ASy8EuNXbVVXp9g==}
@@ -2330,6 +2361,31 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@dnd-kit/accessibility@3.1.1(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/accessibility': 3.1.1(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      react-dom: 19.2.8(react@19.2.8)
+      tslib: 2.8.1
+
+  '@dnd-kit/sortable@10.0.0(@dnd-kit/core@6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8))(react@19.2.8)':
+    dependencies:
+      '@dnd-kit/core': 6.3.1(react-dom@19.2.8(react@19.2.8))(react@19.2.8)
+      '@dnd-kit/utilities': 3.2.2(react@19.2.8)
+      react: 19.2.8
+      tslib: 2.8.1
+
+  '@dnd-kit/utilities@3.2.2(react@19.2.8)':
+    dependencies:
+      react: 19.2.8
+      tslib: 2.8.1
 
   '@emnapi/core@2.0.0-alpha.3':
     dependencies:

--- a/shared/src/engine/round.test.ts
+++ b/shared/src/engine/round.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest';
+import type { RoundConfig } from '../schemas/config.js';
+import { canFinishRound, nextRound, type SortState } from './round.js';
+
+function state(overrides: Partial<SortState> = {}): SortState {
+  return {
+    participantId: 'p1',
+    round: 1,
+    queue: [],
+    kept: [],
+    discarded: [],
+    totalDiscarded: 0,
+    ...overrides,
+  };
+}
+
+describe('canFinishRound', () => {
+  const roundCfg: RoundConfig = { name: 'Round 1', keep: 3, rank: false };
+
+  it('is incomplete whenever the queue still has cards, regardless of kept count', () => {
+    expect(canFinishRound(state({ queue: ['a'], kept: ['b', 'c', 'd'] }), roundCfg)).toEqual({ incomplete: true });
+  });
+
+  it('needs a trim when kept exceeds the keep-count and the queue is empty', () => {
+    expect(canFinishRound(state({ kept: ['a', 'b', 'c', 'd'] }), roundCfg)).toEqual({ needTrim: 1 });
+  });
+
+  it('is ok at exactly the keep-count', () => {
+    expect(canFinishRound(state({ kept: ['a', 'b', 'c'] }), roundCfg)).toEqual({ ok: true });
+  });
+
+  // 01.4: keeping fewer than the round's keep-count is a valid outcome once
+  // the queue is empty — there's nothing left to decide on, so this is not
+  // "incomplete". Continue is enabled whenever kept <= N.
+  it('is ok under the keep-count once the queue is empty', () => {
+    expect(canFinishRound(state({ kept: ['a'] }), roundCfg)).toEqual({ ok: true });
+    expect(canFinishRound(state({ kept: [] }), roundCfg)).toEqual({ ok: true });
+  });
+
+  it("keep: 'any' is always ok once the queue is empty, no matter how many are kept", () => {
+    const anyRound: RoundConfig = { name: 'Round 1', keep: 'any', rank: false };
+    expect(canFinishRound(state({ kept: [] }), anyRound)).toEqual({ ok: true });
+    expect(canFinishRound(state({ kept: ['a', 'b', 'c', 'd', 'e'] }), anyRound)).toEqual({ ok: true });
+  });
+});
+
+describe('nextRound', () => {
+  const config = { rounds: [{ name: 'Round 1', keep: 3, rank: false } as RoundConfig, { name: 'Round 2', keep: 1, rank: true }] };
+
+  it('reshuffles kept into the next round queue and rolls up the discard count', () => {
+    const current = state({ round: 1, kept: ['a', 'b'], discarded: ['c', 'd'], totalDiscarded: 5 });
+    const next = nextRound(current, config);
+    expect(next.round).toBe(2);
+    expect(next.kept).toEqual([]);
+    expect(next.discarded).toEqual([]);
+    expect(next.totalDiscarded).toBe(7);
+    expect(new Set(next.queue)).toEqual(new Set(['a', 'b']));
+  });
+
+  it('throws when there is no next round in the config', () => {
+    const current = state({ round: 2, kept: ['a'] });
+    expect(() => nextRound(current, config)).toThrow(/no round 3/);
+  });
+});

--- a/shared/src/engine/round.ts
+++ b/shared/src/engine/round.ts
@@ -35,19 +35,19 @@ export function nextRound(sortState: SortState, config: { rounds: readonly Round
 
 export type FinishStatus = { ok: true } | { needTrim: number } | { incomplete: true };
 
-/** Whether a round's sort is done, needs trimming down to the keep-count, or isn't finished yet. */
+/**
+ * Whether a round's sort is done, needs trimming down to the keep-count, or
+ * isn't finished yet. `incomplete` means only one thing: there are still
+ * cards in the queue. Once the queue is empty, keeping fewer than the
+ * round's keep-count is a valid outcome (01.4) — over the count needs a
+ * trim, at or under it is always `ok`.
+ */
 export function canFinishRound(sortState: Pick<SortState, 'queue' | 'kept'>, roundCfg: RoundConfig): FinishStatus {
   if (sortState.queue.length > 0) {
     return { incomplete: true };
   }
-  if (roundCfg.keep === 'any') {
-    return { ok: true };
-  }
-  if (sortState.kept.length > roundCfg.keep) {
+  if (roundCfg.keep !== 'any' && sortState.kept.length > roundCfg.keep) {
     return { needTrim: sortState.kept.length - roundCfg.keep };
-  }
-  if (sortState.kept.length < roundCfg.keep) {
-    return { incomplete: true };
   }
   return { ok: true };
 }

--- a/specs/01-core/01.4-round-flow.md
+++ b/specs/01-core/01.4-round-flow.md
@@ -48,24 +48,26 @@ functions — trim and rank are conditional phases of the same flow, not pages.
   ships with 02.1 presence wiring).
 
 ## Acceptance criteria
-- [ ] `canFinishRound`/`nextRound` wiring unit-tested through the store: over-limit →
+- [x] `canFinishRound`/`nextRound` wiring unit-tested through the store: over-limit →
       trim; at/under limit → advance; discard counter accumulates across rounds
       (`app/src/stores/round-flow.test.ts`).
-- [ ] **Invariant 3 (client half, PRD §6.3):** it is impossible to reach the next round
+- [x] **Invariant 3 (client half, PRD §6.3):** it is impossible to reach the next round
       with kept > keep-count — store test attempts to force it; TrimGrid Confirm stays
       disabled until ≤ N (component test).
-- [ ] TrimGrid: cut/uncut by pointer and keyboard, countdown text correct, confirm moves
+- [x] TrimGrid: cut/uncut by pointer and keyboard, countdown text correct, confirm moves
       cut cards to discarded (`app/src/engine-ui/trim-grid.test.tsx`).
-- [ ] RankBoard reorders by pointer drag and by keyboard sensor alone; final order lands
+- [x] RankBoard reorders by pointer drag and by keyboard sensor alone; final order lands
       in `ranking` (`app/src/engine-ui/rank-board.test.tsx`).
-- [ ] Refresh during trim and during rank restores that exact phase and selection
+- [x] Refresh during trim and during rank restores that exact phase and selection
       (E2E `e2e/round-flow-refresh.spec.ts`).
-- [ ] Full solo journey E2E, desktop + mobile viewports: dev-12 deck, rounds 12 → keep 8
+- [x] Full solo journey E2E, desktop + mobile viewports: dev-12 deck, rounds 12 → keep 8
       → keep 3 (ranked): sort → trim (deliberately over-keep) → next round → rank →
       result screen shows 3 ordered cards (`e2e/solo-journey.spec.ts`).
-- [ ] Keyboard-only solo journey passes (same spec, keyboard project).
-- [ ] Ranking round-trips: result screen order matches RankBoard order after refresh.
-- [ ] `pnpm gate` green.
+- [x] Keyboard-only solo journey passes (same spec, keyboard project) — implemented as a
+      keyboard-only test in the same file/projects rather than a dedicated Playwright
+      "keyboard" project; see final report deviation.
+- [x] Ranking round-trips: result screen order matches RankBoard order after refresh.
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -60,7 +60,7 @@
       "depends_on": [
         "01.3"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "02.1",


### PR DESCRIPTION
Implements [specs/01-core/01.4-round-flow.md](specs/01-core/01.4-round-flow.md). Completes phase **01-core**, unblocking all of 02-multiplayer.

## What landed
- **`getPhase`** in `app/src/stores/createSortStore.ts` — the flow position is *derived* from state + config, not stored. No phase field to fall out of sync on refresh, and the 40→8→3 shape (or any other) falls out of config with no per-round special-casing (tenet 4).
- Store actions extending 01.3: `toggleCut`, `confirmTrim`, `continueRound`, `setRanking`, `confirmRank`.
- `app/src/engine-ui/TrimGrid.tsx` — roving-tabindex grid, cut/uncut, countdown, confirm.
- `app/src/engine-ui/RankBoard.tsx` — `@dnd-kit/core` + sortable with keyboard sensor and `announcements` (both named explicitly by the spec).
- `app/src/routes/Sort.tsx` — now a phase-driven orchestrator (sort → round-complete → trim → rank → result) on a dev-12 deck (12 → keep 8 → keep 3 ranked).

## Acceptance criteria
All boxes checked, each backed by a passing command.

## Test evidence
`pnpm gate` green, verified independently in a clean install of the worktree:

```
Test Files  26 passed (26)
     Tests  184 passed (184)
  32 passed (30.6s)   [Playwright e2e, desktop-chromium + mobile-chromium]
```

## Deviations

**1. Fixed a bug in the merged `shared/src/engine/round.ts`.** `canFinishRound` treated *"kept < keep-count with an empty queue"* as `incomplete`, directly contradicting this spec's line 21 — *"Keeping fewer than N is allowed — Continue is enabled whenever kept ≤ N"*. Caught by `sort-keyboard.spec.ts` failing. `canFinishRound` had **no test coverage at all** (`round.test.ts` didn't exist), so this is a pure fix; added `shared/src/engine/round.test.ts` covering the corrected contract.

  I verified this doesn't touch invariant 3: `canFinishRound` is called only from the client store, never server-side. Server-side keep-count enforcement on reveal payloads still lives in `apply-intent` and is unchanged.

**2. Keyboard-only journey runs in the existing projects**, not a dedicated Playwright `keyboard` project — none existed, and adding one triples the CI matrix for one file's benefit.

**3. `round-flow-refresh.spec.ts` reorders the RankBoard by pointer drag, not the keyboard sensor.** Real-browser ArrowDown reordering was genuinely flaky under parallel load (dnd-kit rect-measurement race, plus its page-scroll-vs-move handling).

  **Residual risk worth your judgment:** the keyboard sensor's exact reorder output is proven in `rank-board.test.tsx` under jsdom with real `userEvent` key presses and mocked rects, and the keyboard-only solo journey *reaches* the board — but exact keyboard ordering is never asserted in a real browser. Given accessibility is a gate here, that's a thinner guarantee than the pointer path has. dnd-kit's keyboard sensor could regress in a real browser and this suite would stay green.

## Test corrected (not loosened)
`SortRound.test.tsx`'s "shows the Round complete placeholder" — this spec moves terminal-state ownership out of `SortRound` (now only the active-sort phase) into `routes/Sort`. Rewritten to assert `SortRound` renders nothing once the queue empties. `sort-keyboard`, `sort-privacy` and `sort-kept-tray` were updated for the new dev-12 two-round demo config the 01.4 E2E criteria require.

## Review
`ponytail-review` found nothing to cut — `getPhase` being derived rather than stored is the right call, and `@dnd-kit` is named by the spec rather than chosen speculatively. Correctness pass found no defects beyond the `round.ts` bug fixed above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)