### PR TITLE
feat(03.1): Game designer

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -15,6 +15,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@dnd-kit/utilities": "^3.2.2",
     "@fontsource/fraunces": "^5.3.0",
+    "@values-cards/decks": "workspace:*",
     "@values-cards/shared": "workspace:*",
     "framer-motion": "^12.43.0",
     "react": "^19.2.0",

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -1,5 +1,6 @@
 import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
+import { Create } from './routes/Create';
 import { Join } from './routes/Join';
 import { KitchenSink } from './routes/KitchenSink';
 import { Landing } from './routes/Landing';
@@ -22,6 +23,8 @@ function currentRoute() {
   const joinMatch = path.match(JOIN_PATH_PATTERN);
   if (joinMatch) return <Join code={joinMatch[1]} />;
   switch (path) {
+    case '/create':
+      return <Create />;
     case '/kitchen-sink':
       return <KitchenSink />;
     case '/sort':

--- a/app/src/routes/Create.test.tsx
+++ b/app/src/routes/Create.test.tsx
@@ -1,0 +1,28 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { Create } from './Create';
+
+afterEach(cleanup);
+
+describe('Create', () => {
+  it('disables Create game until a name is entered', () => {
+    render(<Create />);
+    expect(screen.getByRole('button', { name: 'Create game' })).toHaveProperty('disabled', true);
+    fireEvent.change(screen.getByLabelText('Your name'), { target: { value: 'Coach' } });
+    expect(screen.getByRole('button', { name: 'Create game' })).toHaveProperty('disabled', false);
+  });
+
+  it('disables Create game once the designer produces an invalid config (switching to a too-small deck)', () => {
+    render(<Create />);
+    fireEvent.change(screen.getByLabelText('Your name'), { target: { value: 'Coach' } });
+    fireEvent.click(screen.getByRole('button', { name: 'Customize' }));
+
+    // The classic template's "Top 8" round needs 8 cards — Dev 12 (12 cards) still
+    // fits, so switch further down: pick Dev 12, then push a round's keep above it.
+    fireEvent.click(screen.getByRole('radio', { name: /Dev 12/ }));
+    const keepInputs = screen.getAllByRole('spinbutton', { name: 'Keep count' });
+    fireEvent.change(keepInputs[0] as HTMLElement, { target: { value: '20' } });
+
+    expect(screen.getByRole('button', { name: 'Create game' })).toHaveProperty('disabled', true);
+  });
+});

--- a/app/src/routes/Create.tsx
+++ b/app/src/routes/Create.tsx
@@ -1,0 +1,148 @@
+import { useEffect, useRef, useState } from 'react';
+import { validateConfig, type Deck, type GameConfig } from '@values-cards/shared';
+import { CLASSIC_TEMPLATE } from '@values-cards/decks/templates.js';
+import { Button } from '../components/Button';
+import { ConnectionPill } from '../session/ConnectionPill';
+import { intents } from '../session/intents';
+import { loadToken } from '../session/tokens';
+import { useSession } from '../session/useSession';
+import { Designer } from './create/designer';
+import { Lobby } from './lobby';
+
+const CREATOR_TOKEN_KEY = (code: string) => `vc:${code}:creator`;
+
+/** Landing's "Start a game" (PRD §4.1): template-first, with the full designer behind
+ *  "Customize". Replaces the 01.2 dev-only quick-create stand-in. */
+export function Create() {
+  const [config, setConfig] = useState<GameConfig>(CLASSIC_TEMPLATE);
+  const [titleTouched, setTitleTouched] = useState(false);
+  const [customizing, setCustomizing] = useState(false);
+  const [name, setName] = useState('');
+  const [creating, setCreating] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
+  const [created, setCreated] = useState<{ code: string; creatorToken: string } | null>(null);
+
+  const result = validateConfig(config);
+  const canCreate = result.ok && name.trim().length > 0 && !creating;
+
+  function handleDeckChange(deck: Deck) {
+    setConfig((previous) => ({ ...previous, deck, title: titleTouched ? previous.title : `${deck.name} Sort` }));
+  }
+
+  async function createGame() {
+    setCreating(true);
+    setCreateError(null);
+    try {
+      const response = await fetch('/api/session', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ config }),
+      });
+      if (!response.ok) throw new Error('create failed');
+      const body = (await response.json()) as { code: string; creatorToken: string };
+      localStorage.setItem(CREATOR_TOKEN_KEY(body.code), body.creatorToken);
+      setCreated(body);
+    } catch {
+      setCreateError('Could not create a game. Try again.');
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  if (created) {
+    return <CreateLobby code={created.code} creatorToken={created.creatorToken} name={name.trim()} />;
+  }
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+      <h1 className="font-display text-3xl font-semibold">Start a game</h1>
+
+      <label className="flex w-full max-w-sm flex-col gap-1 text-sm font-semibold" htmlFor="creator-name">
+        Your name
+        <input
+          id="creator-name"
+          value={name}
+          onChange={(event) => setName(event.target.value)}
+          className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+        />
+      </label>
+
+      {!customizing ? (
+        <section className="flex w-full max-w-sm flex-col gap-3 rounded-control border border-ink-muted bg-surface-raised p-4">
+          <h2 className="font-display text-xl font-semibold">{config.title}</h2>
+          <p className="text-sm text-ink-muted">
+            {config.deck.name} ({config.deck.cards.length} cards) · {config.rounds.map((round) => round.name).join(' → ')}
+          </p>
+          <Button type="button" variant="secondary" onClick={() => setCustomizing(true)}>
+            Customize
+          </Button>
+        </section>
+      ) : (
+        <div className="w-full max-w-sm">
+          <Designer
+            config={config}
+            onTitleChange={(title) => {
+              setTitleTouched(true);
+              setConfig((previous) => ({ ...previous, title }));
+            }}
+            onDeckChange={handleDeckChange}
+            onRoundsChange={(rounds) => setConfig((previous) => ({ ...previous, rounds }))}
+            onFacilitatedChange={(facilitated) => setConfig((previous) => ({ ...previous, facilitated }))}
+          />
+        </div>
+      )}
+
+      {createError ? (
+        <p role="alert" className="text-danger">
+          {createError}
+        </p>
+      ) : null}
+
+      <Button type="button" onClick={createGame} disabled={!canCreate}>
+        {creating ? 'Creating…' : 'Create game'}
+      </Button>
+    </main>
+  );
+}
+
+/** Joins the freshly created session as its facilitator, then hands off to the shared
+ *  `Lobby` — mirrors `Join.tsx`'s `JoiningSession`, the only other place a socket join
+ *  happens, rather than a second connect-and-join implementation. */
+function CreateLobby({ code, creatorToken, name }: { code: string; creatorToken: string; name: string }) {
+  const { state, connection, send } = useSession(code);
+  const sentJoinRef = useRef(false);
+
+  useEffect(() => {
+    if (connection !== 'live') return;
+    if (sentJoinRef.current) return;
+    sentJoinRef.current = true;
+    send(intents.join(name), creatorToken);
+  }, [connection, name, send, creatorToken]);
+
+  useEffect(() => {
+    const token = loadToken(code);
+    if (!token || !state) return;
+    if (state.phase === 'active') {
+      // 01.3/01.4 own the real sort route; this is the placeholder hand-off (out of
+      // scope here), same as Join.tsx's.
+      window.location.assign('/sort');
+    }
+  }, [state, code]);
+
+  const token = loadToken(code);
+  if (!state || !token || !state.participants[token.participantId]) {
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-ink">
+        <ConnectionPill connection={connection} />
+        <h1 className="font-display text-2xl font-semibold">Creating your game…</h1>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <ConnectionPill connection={connection} />
+      <Lobby code={code} state={state} participantId={token.participantId} send={send} />
+    </>
+  );
+}

--- a/app/src/routes/Join.tsx
+++ b/app/src/routes/Join.tsx
@@ -4,6 +4,7 @@ import { ConnectionPill } from '../session/ConnectionPill';
 import { intents } from '../session/intents';
 import { loadToken } from '../session/tokens';
 import { useSession } from '../session/useSession';
+import { Lobby } from './lobby';
 
 const CODE_PATTERN = /^[A-Z0-9]{6}$/;
 const CREATOR_TOKEN_KEY = (code: string) => `vc:${code}:creatorToken`;
@@ -112,11 +113,21 @@ function JoiningSession({ code, name }: { code: string; name: string }) {
   useEffect(() => {
     const token = loadToken(code);
     if (!token || !state) return;
-    if (state.participants[token.participantId]) {
+    if (state.phase === 'active') {
       // 01.3/01.4 own the real sort route; this is the placeholder hand-off (out of scope here).
       window.location.assign('/sort');
     }
   }, [state, code]);
+
+  const token = loadToken(code);
+  if (state && token && state.participants[token.participantId]) {
+    return (
+      <>
+        <ConnectionPill connection={connection} />
+        <Lobby code={code} state={state} participantId={token.participantId} send={send} />
+      </>
+    );
+  }
 
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-ink">

--- a/app/src/routes/Landing.tsx
+++ b/app/src/routes/Landing.tsx
@@ -1,22 +1,3 @@
-/**
- * "Start a session" is a dev-only stand-in for the real create flow (03.1): it calls
- * `POST /api/session` with the classic template, stashes the minted `creatorToken`
- * for the join form to pick up, then hands off to `/join/:code`.
- */
-async function startSession(event: React.MouseEvent<HTMLAnchorElement>) {
-  event.preventDefault();
-  try {
-    const response = await fetch('/api/session', { method: 'POST', headers: { 'content-type': 'application/json' }, body: '{}' });
-    if (!response.ok) return;
-    const { code, creatorToken } = (await response.json()) as { code: string; creatorToken: string };
-    sessionStorage.setItem(`vc:${code}:creatorToken`, creatorToken);
-    window.location.assign(`/join/${code}`);
-  } catch {
-    // Dev-only convenience ahead of 03.1's real create flow — fail silently, the
-    // "Start a session" link still degrades to the join form via its href.
-  }
-}
-
 export function Landing() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-surface text-ink">
@@ -24,8 +5,7 @@ export function Landing() {
       <p className="text-ink-muted">Sort what matters. Keep what counts.</p>
       <nav aria-label="Get started" className="flex gap-4">
         <a
-          href="/join"
-          onClick={startSession}
+          href="/create"
           className="rounded-lg bg-accent px-6 py-3 font-semibold text-on-accent"
         >
           Start a session

--- a/app/src/routes/create/deck-picker.tsx
+++ b/app/src/routes/create/deck-picker.tsx
@@ -1,0 +1,51 @@
+import type { Deck } from '@values-cards/shared';
+import leadershipForty from '@values-cards/decks/decks/leadership-40.json';
+import extendedSeventyTwo from '@values-cards/decks/decks/extended-72.json';
+import devTwelve from '@values-cards/decks/decks/dev-12.json';
+
+/** The three bundled decks (PRD §4.1). Custom CSV decks are 03.2. */
+export const BUNDLED_DECKS: Deck[] = [leadershipForty, extendedSeventyTwo, devTwelve] as Deck[];
+
+const PREVIEW_COUNT = 3;
+
+export interface DeckPickerProps {
+  decks?: Deck[];
+  selected: Deck;
+  onSelect: (deck: Deck) => void;
+  disabled?: boolean;
+}
+
+/** Radio group over the bundled decks — card count + a first-cards preview per option. */
+export function DeckPicker({ decks = BUNDLED_DECKS, selected, onSelect, disabled = false }: DeckPickerProps) {
+  return (
+    <fieldset className="flex flex-col gap-3" disabled={disabled}>
+      <legend className="font-display text-lg font-semibold text-ink">Deck</legend>
+      <div className="flex flex-col gap-3 sm:flex-row">
+        {decks.map((deck) => {
+          const id = `deck-${deck.name}`;
+          const isSelected = deck.name === selected.name;
+          return (
+            <label
+              key={deck.name}
+              htmlFor={id}
+              className={`flex flex-1 cursor-pointer flex-col gap-1 rounded-control border p-4 ${isSelected ? 'border-accent bg-accent-subtle' : 'border-ink-muted bg-surface-raised'}`}
+            >
+              <span className="flex items-center gap-2 font-semibold text-ink">
+                <input id={id} type="radio" name="deck" checked={isSelected} onChange={() => onSelect(deck)} />
+                {deck.name}
+              </span>
+              <span className="text-sm text-ink-muted">{deck.cards.length} cards</span>
+              <span className="text-xs text-ink-muted">
+                {deck.cards
+                  .slice(0, PREVIEW_COUNT)
+                  .map((card) => card.value)
+                  .join(', ')}
+                …
+              </span>
+            </label>
+          );
+        })}
+      </div>
+    </fieldset>
+  );
+}

--- a/app/src/routes/create/designer.test.tsx
+++ b/app/src/routes/create/designer.test.tsx
@@ -1,0 +1,49 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Deck, GameConfig } from '@values-cards/shared';
+import leadershipForty from '@values-cards/decks/decks/leadership-40.json';
+import { Designer } from './designer';
+
+afterEach(cleanup);
+
+function Fixture() {
+  const [config, setConfig] = useState<GameConfig>({
+    title: 'Test',
+    deck: leadershipForty as Deck,
+    // 30 fits Leadership 40 (40 cards) but not Dev 12 (12 cards) — switching
+    // decks below must surface that immediately.
+    rounds: [
+      { name: 'Narrow', keep: 30, rank: false },
+      { name: 'Final', keep: 3, rank: true },
+    ],
+    theme: { variant: 'default' },
+    facilitated: true,
+  });
+  return (
+    <Designer
+      config={config}
+      onTitleChange={(title) => setConfig((c) => ({ ...c, title }))}
+      onDeckChange={(deck) => setConfig((c) => ({ ...c, deck }))}
+      onRoundsChange={(rounds) => setConfig((c) => ({ ...c, rounds }))}
+      onFacilitatedChange={(facilitated) => setConfig((c) => ({ ...c, facilitated }))}
+    />
+  );
+}
+
+describe('Designer', () => {
+  it('switching to a smaller deck flags now-invalid keep-counts immediately', () => {
+    render(<Fixture />);
+    expect(screen.queryByText(/keeps 30 but the deck has only/)).toBeNull();
+
+    fireEvent.click(screen.getByRole('radio', { name: /Dev 12/ }));
+
+    expect(screen.getByText(/keeps 30 but the deck has only 12/)).toBeDefined();
+  });
+
+  it('labels the title field and facilitation toggle', () => {
+    render(<Fixture />);
+    expect(screen.getByRole('textbox', { name: 'Game title' })).toBeDefined();
+    expect(screen.getByRole('checkbox', { name: /Facilitation mode/ })).toBeDefined();
+  });
+});

--- a/app/src/routes/create/designer.tsx
+++ b/app/src/routes/create/designer.tsx
@@ -1,0 +1,63 @@
+import { validateConfig, type GameConfig } from '@values-cards/shared';
+import { DeckPicker } from './deck-picker';
+import { RoundEditor } from './round-editor';
+
+export interface DesignerProps {
+  config: GameConfig;
+  onTitleChange: (title: string) => void;
+  onDeckChange: (deck: GameConfig['deck']) => void;
+  onRoundsChange: (rounds: GameConfig['rounds']) => void;
+  onFacilitatedChange: (facilitated: boolean) => void;
+  disabled?: boolean;
+}
+
+/** The full designer surface: title, deck, rounds, facilitation. The one source of
+ *  truth for "is this config good enough to create/save" is `validateConfig` (00.2) —
+ *  this component never duplicates its rules. */
+export function Designer({
+  config,
+  onTitleChange,
+  onDeckChange,
+  onRoundsChange,
+  onFacilitatedChange,
+  disabled = false,
+}: DesignerProps) {
+  const result = validateConfig(config);
+  const errors = result.ok ? [] : result.errors;
+
+  return (
+    <div className="flex flex-col gap-6">
+      <label className="flex flex-col gap-1 text-sm font-semibold" htmlFor="game-title">
+        Game title
+        <input
+          id="game-title"
+          value={config.title}
+          onChange={(event) => onTitleChange(event.target.value)}
+          disabled={disabled}
+          className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+        />
+      </label>
+
+      <DeckPicker selected={config.deck} onSelect={onDeckChange} disabled={disabled} />
+
+      <RoundEditor
+        rounds={config.rounds}
+        deckSize={config.deck.cards.length}
+        errors={errors}
+        onChange={onRoundsChange}
+        disabled={disabled}
+      />
+
+      <label className="flex items-center gap-2 text-sm font-semibold" htmlFor="facilitation-toggle">
+        <input
+          id="facilitation-toggle"
+          type="checkbox"
+          checked={config.facilitated}
+          onChange={(event) => onFacilitatedChange(event.target.checked)}
+          disabled={disabled}
+        />
+        Facilitation mode (you are the facilitator)
+      </label>
+    </div>
+  );
+}

--- a/app/src/routes/create/round-editor.test.tsx
+++ b/app/src/routes/create/round-editor.test.tsx
@@ -1,0 +1,83 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { useState } from 'react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { validateConfig, type GameConfig, type RoundConfig } from '@values-cards/shared';
+import { RoundEditor } from './round-editor';
+
+afterEach(cleanup);
+
+const DECK = { name: 'Test Deck', cards: Array.from({ length: 10 }, (_, i) => ({ value: `Card ${i}`, description: `Desc ${i}` })) };
+
+function baseConfig(rounds: RoundConfig[]): GameConfig {
+  return { title: 'Test', deck: DECK, rounds, theme: { variant: 'default' }, facilitated: true };
+}
+
+function Fixture({ initialRounds }: { initialRounds: RoundConfig[] }) {
+  const [rounds, setRounds] = useState(initialRounds);
+  const errors = (() => {
+    const result = validateConfig(baseConfig(rounds));
+    return result.ok ? [] : result.errors;
+  })();
+  return <RoundEditor rounds={rounds} deckSize={DECK.cards.length} errors={errors} onChange={setRounds} />;
+}
+
+describe('RoundEditor', () => {
+  it('renders labelled fields for each round', () => {
+    render(<Fixture initialRounds={[{ name: 'Narrow', keep: 8, rank: false }, { name: 'Final', keep: 3, rank: true }]} />);
+    expect(screen.getByRole('textbox', { name: 'Round 1 name' })).toHaveProperty('value', 'Narrow');
+    expect(screen.getAllByRole('spinbutton', { name: 'Keep count' })).toHaveLength(2);
+  });
+
+  it('flags non-decreasing keep-counts inline and nothing else is broken', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 5, rank: false }, { name: 'B', keep: 5, rank: false }]} />);
+    expect(screen.getByText(/must strictly decrease/)).toBeDefined();
+  });
+
+  it('flags keep > deck size inline', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 20, rank: false }]} />);
+    expect(screen.getByText(/keeps 20 but the deck has only 10/)).toBeDefined();
+  });
+
+  it('flags more than 6 rounds', () => {
+    const rounds: RoundConfig[] = Array.from({ length: 7 }, (_, i) => ({ name: `R${i}`, keep: 6 - i > 0 ? 6 - i : 1, rank: false }));
+    render(<Fixture initialRounds={rounds} />);
+    expect(screen.getByText(/between 1 and 6 rounds/)).toBeDefined();
+  });
+
+  it('flags keep-any used outside round 1', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 5, rank: false }, { name: 'B', keep: 'any', rank: false }]} />);
+    expect(screen.getByText(/only allowed on round 1/)).toBeDefined();
+  });
+
+  it('flags rank used outside the final round', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 5, rank: true }, { name: 'B', keep: 3, rank: false }]} />);
+    expect(screen.getByText(/only allowed on the final round/)).toBeDefined();
+  });
+
+  it('only offers "keep any" on round 1 and "rank" on the final round', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 8, rank: false }, { name: 'B', keep: 3, rank: true }]} />);
+    expect(screen.getByRole('checkbox', { name: /Keep any/ })).toBeDefined();
+    expect(screen.queryAllByRole('checkbox', { name: /Keep any/ })).toHaveLength(1);
+    expect(screen.getByRole('checkbox', { name: /Rank final results/ })).toBeDefined();
+    expect(screen.queryAllByRole('checkbox', { name: /Rank final results/ })).toHaveLength(1);
+  });
+
+  it('adds and removes rounds, respecting the 1-6 bound', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 8, rank: true }]} />);
+    expect(screen.getByRole('button', { name: 'Remove round 1' })).toHaveProperty('disabled', true);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Add round' }));
+    expect(screen.getAllByRole('button', { name: /Remove round/ })).toHaveLength(2);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Remove round 2' }));
+    expect(screen.getAllByRole('button', { name: /Remove round/ })).toHaveLength(1);
+  });
+
+  it('is fully keyboard operable (tab to a field and type)', () => {
+    render(<Fixture initialRounds={[{ name: 'A', keep: 8, rank: true }]} />);
+    const nameInput = screen.getByRole('textbox', { name: 'Round 1 name' });
+    nameInput.focus();
+    fireEvent.change(nameInput, { target: { value: 'Updated' } });
+    expect(nameInput).toHaveProperty('value', 'Updated');
+  });
+});

--- a/app/src/routes/create/round-editor.tsx
+++ b/app/src/routes/create/round-editor.tsx
@@ -1,0 +1,150 @@
+import type { ConfigError, RoundConfig } from '@values-cards/shared';
+import { Button } from '../../components/Button';
+
+const MAX_ROUNDS = 6;
+const MIN_ROUNDS = 1;
+
+export interface RoundEditorProps {
+  rounds: RoundConfig[];
+  deckSize: number;
+  errors: ConfigError[];
+  onChange: (rounds: RoundConfig[]) => void;
+  disabled?: boolean;
+}
+
+function errorsAt(errors: ConfigError[], index: number, field: 'keep' | 'rank'): ConfigError[] {
+  return errors.filter((error) => error.path[0] === 'rounds' && error.path[1] === index && error.path[2] === field);
+}
+
+/** New round's keep-count defaults just under the previous round's, clamped to the deck. */
+function defaultKeepFor(previous: RoundConfig | undefined, deckSize: number): number {
+  const previousKeep = typeof previous?.keep === 'number' ? previous.keep : deckSize;
+  return Math.max(1, Math.min(deckSize, previousKeep - 1));
+}
+
+/**
+ * Round add/remove/edit — the whole surface is driven by `validateConfig`'s errors
+ * (00.2), never a parallel set of UI-only rules (tenet 4). One row per round; round 1
+ * alone gets the "keep any" toggle, the last round alone gets the rank toggle, exactly
+ * mirroring `GameConfigSchema`'s cross-field refinements.
+ */
+export function RoundEditor({ rounds, deckSize, errors, onChange, disabled = false }: RoundEditorProps) {
+  const roundCountErrors = errors.filter((error) => error.path.length === 1 && error.path[0] === 'rounds');
+
+  function updateRound(index: number, patch: Partial<RoundConfig>) {
+    onChange(rounds.map((round, i) => (i === index ? { ...round, ...patch } : round)));
+  }
+
+  function addRound() {
+    if (rounds.length >= MAX_ROUNDS) return;
+    const previous = rounds[rounds.length - 1];
+    onChange([...rounds, { name: `Round ${rounds.length + 1}`, keep: defaultKeepFor(previous, deckSize), rank: false }]);
+  }
+
+  function removeRound(index: number) {
+    if (rounds.length <= MIN_ROUNDS) return;
+    onChange(rounds.filter((_, i) => i !== index));
+  }
+
+  return (
+    <fieldset className="flex flex-col gap-4" disabled={disabled}>
+      <legend className="font-display text-lg font-semibold text-ink">Rounds</legend>
+      <div aria-live="polite" className="flex flex-col gap-4">
+        {roundCountErrors.length > 0 ? (
+          <p role="alert" className="text-sm text-danger">
+            {roundCountErrors[0]?.message}
+          </p>
+        ) : null}
+        {rounds.map((round, index) => {
+          const isFirst = index === 0;
+          const isLast = index === rounds.length - 1;
+          const keepErrors = errorsAt(errors, index, 'keep');
+          const rankErrors = errorsAt(errors, index, 'rank');
+          const keepAny = round.keep === 'any';
+
+          return (
+            <div key={index} className="flex flex-col gap-2 rounded-control border border-ink-muted p-4">
+              <div className="flex items-end gap-3">
+                <label className="flex flex-1 flex-col gap-1 text-sm font-semibold" htmlFor={`round-${index}-name`}>
+                  Round {index + 1} name
+                  <input
+                    id={`round-${index}-name`}
+                    value={round.name}
+                    onChange={(event) => updateRound(index, { name: event.target.value })}
+                    className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+                  />
+                </label>
+                <Button
+                  type="button"
+                  variant="ghost"
+                  size="sm"
+                  onClick={() => removeRound(index)}
+                  disabled={disabled || rounds.length <= MIN_ROUNDS}
+                  aria-label={`Remove round ${index + 1}`}
+                >
+                  Remove
+                </Button>
+              </div>
+
+              {isFirst ? (
+                <label className="flex items-center gap-2 text-sm font-semibold" htmlFor={`round-${index}-keep-any`}>
+                  <input
+                    id={`round-${index}-keep-any`}
+                    type="checkbox"
+                    checked={keepAny}
+                    onChange={(event) =>
+                      updateRound(index, { keep: event.target.checked ? 'any' : defaultKeepFor(undefined, deckSize) })
+                    }
+                  />
+                  Keep any (open triage)
+                </label>
+              ) : null}
+
+              {!keepAny ? (
+                <label className="flex flex-col gap-1 text-sm font-semibold" htmlFor={`round-${index}-keep`}>
+                  Keep count
+                  <input
+                    id={`round-${index}-keep`}
+                    type="number"
+                    min={1}
+                    value={typeof round.keep === 'number' ? round.keep : ''}
+                    onChange={(event) => updateRound(index, { keep: Number(event.target.value) || 0 })}
+                    aria-describedby={keepErrors.length > 0 ? `round-${index}-keep-error` : undefined}
+                    aria-invalid={keepErrors.length > 0}
+                    className="w-32 rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+                  />
+                </label>
+              ) : null}
+              {keepErrors.length > 0 ? (
+                <p id={`round-${index}-keep-error`} className="text-sm text-danger">
+                  {keepErrors[0]?.message}
+                </p>
+              ) : null}
+
+              {isLast ? (
+                <label className="flex items-center gap-2 text-sm font-semibold" htmlFor={`round-${index}-rank`}>
+                  <input
+                    id={`round-${index}-rank`}
+                    type="checkbox"
+                    checked={round.rank}
+                    onChange={(event) => updateRound(index, { rank: event.target.checked })}
+                    aria-describedby={rankErrors.length > 0 ? `round-${index}-rank-error` : undefined}
+                  />
+                  Rank final results
+                </label>
+              ) : null}
+              {rankErrors.length > 0 ? (
+                <p id={`round-${index}-rank-error`} className="text-sm text-danger">
+                  {rankErrors[0]?.message}
+                </p>
+              ) : null}
+            </div>
+          );
+        })}
+      </div>
+      <Button type="button" variant="secondary" size="sm" onClick={addRound} disabled={disabled || rounds.length >= MAX_ROUNDS}>
+        Add round
+      </Button>
+    </fieldset>
+  );
+}

--- a/app/src/routes/lobby.tsx
+++ b/app/src/routes/lobby.tsx
@@ -1,0 +1,114 @@
+import { useState } from 'react';
+import { validateConfig, type GameConfig, type Intent, type SessionState } from '@values-cards/shared';
+import { Button } from '../components/Button';
+import { Modal } from '../components/Modal';
+import { Toast } from '../components/Toast';
+import { intents } from '../session/intents';
+import { Designer } from './create/designer';
+
+export interface LobbyProps {
+  code: string;
+  state: SessionState;
+  participantId: string;
+  send: (intent: Intent) => void;
+}
+
+/**
+ * The shared waiting room for everyone in `phase: 'lobby'` — creator and joiners
+ * alike (spec 03.1). Shows the code/share link and roster to all; only the
+ * facilitator gets the reopen-designer and start-game controls, and both
+ * disappear the instant the server locks config (tenet: server-enforced, UI
+ * reflects it, never re-derives it).
+ */
+export function Lobby({ code, state, participantId, send }: LobbyProps) {
+  const [editing, setEditing] = useState(false);
+  const [draft, setDraft] = useState<GameConfig>(state.config);
+  const [copied, setCopied] = useState(false);
+
+  const self = state.participants[participantId];
+  const isFacilitator = self?.role === 'facilitator';
+  const shareLink = `${window.location.origin}/join/${code}`;
+
+  function openEditor() {
+    setDraft(state.config);
+    setEditing(true);
+  }
+
+  function saveEditor() {
+    send(intents.updateConfig(participantId, draft));
+    setEditing(false);
+  }
+
+  async function copyLink() {
+    await navigator.clipboard.writeText(shareLink);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  }
+
+  const draftValid = validateConfig(draft).ok;
+
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-8 bg-surface p-8 text-ink">
+      <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
+
+      <section className="flex flex-col items-center gap-3">
+        <p className="font-display text-5xl font-bold tracking-widest">{code}</p>
+        <div className="flex items-center gap-2">
+          <input readOnly value={shareLink} aria-label="Share link" className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-sm text-ink" />
+          <Button type="button" variant="secondary" size="sm" onClick={copyLink}>
+            Copy link
+          </Button>
+        </div>
+        {copied ? <Toast message="Link copied" variant="success" /> : null}
+      </section>
+
+      <section className="w-full max-w-md text-center">
+        <h2 className="mb-2 font-display text-lg font-semibold">Game</h2>
+        <p className="text-sm text-ink-muted">
+          {state.config.deck.name} ({state.config.deck.cards.length} cards) ·{' '}
+          {state.config.rounds.map((round) => round.name).join(' → ')}
+        </p>
+      </section>
+
+      <section className="w-full max-w-md">
+        <h2 className="mb-2 font-display text-lg font-semibold">Players</h2>
+        <ul className="flex flex-col gap-2">
+          {Object.entries(state.participants).map(([id, participant]) => (
+            <li key={id} className="flex items-center justify-between rounded-control border border-ink-muted bg-surface-raised px-3 py-2">
+              <span>{participant.name}</span>
+              <span className="text-sm text-ink-muted">{participant.role === 'facilitator' ? 'Facilitator' : 'Participant'}</span>
+            </li>
+          ))}
+        </ul>
+      </section>
+
+      {state.phase !== 'lobby' ? <p className="text-ink-muted">Config is locked — the game has started.</p> : null}
+
+      {isFacilitator && state.phase === 'lobby' ? (
+        <div className="flex gap-4">
+          <Button type="button" variant="secondary" onClick={openEditor}>
+            Edit game
+          </Button>
+          <Button type="button" onClick={() => send(intents.startGame(participantId))}>
+            Start game
+          </Button>
+        </div>
+      ) : null}
+
+      <Modal open={editing} onClose={() => setEditing(false)} title="Edit game">
+        <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto">
+          <Designer
+            config={draft}
+            onTitleChange={(title) => setDraft({ ...draft, title })}
+            onDeckChange={(deck) => setDraft({ ...draft, deck })}
+            onRoundsChange={(rounds) => setDraft({ ...draft, rounds })}
+            onFacilitatedChange={(facilitated) => setDraft({ ...draft, facilitated })}
+          />
+          <Button type="button" onClick={saveEditor} disabled={!draftValid}>
+            Save changes
+          </Button>
+        </div>
+      </Modal>
+    </main>
+  );
+}

--- a/decks/templates.ts
+++ b/decks/templates.ts
@@ -1,0 +1,20 @@
+import type { Deck, GameConfig } from '@values-cards/shared';
+import leadershipForty from './decks/leadership-40.json';
+
+/**
+ * The one bundled template for 2.0 (PRD §4.1, spec 03.1) — the classic
+ * "Leadership Values — 40 → 8 → 3" exercise. Shared by the create route's
+ * one-tap default and the server's `POST /api/session` fallback so the two
+ * can never drift apart (party/src/default-config.ts re-exports this).
+ */
+export const CLASSIC_TEMPLATE: GameConfig = {
+  title: 'Leadership Values — 40 → 8 → 3',
+  deck: leadershipForty as Deck,
+  rounds: [
+    { name: 'Open triage', keep: 'any', rank: false },
+    { name: 'Top 8', keep: 8, rank: false },
+    { name: 'Top 3', keep: 3, rank: true },
+  ],
+  theme: { variant: 'default' },
+  facilitated: true,
+};

--- a/decks/tsconfig.json
+++ b/decks/tsconfig.json
@@ -3,5 +3,5 @@
   "compilerOptions": {
     "types": ["node"]
   },
-  "include": ["scripts", "decks.test.ts", "vitest.config.ts"]
+  "include": ["scripts", "decks.test.ts", "vitest.config.ts", "templates.ts"]
 }

--- a/e2e/create.spec.ts
+++ b/e2e/create.spec.ts
@@ -1,0 +1,76 @@
+import { expect, test } from '@playwright/test';
+
+/**
+ * Spec 03.1's create flow, full stack against `wrangler dev` (see join.spec.ts).
+ */
+test('one-tap create: landing -> Start -> default template -> Create -> code + share link; a second browser joins and sees the classic config', async ({
+  page,
+  browser,
+}) => {
+  await page.goto('/');
+  await page.getByRole('link', { name: 'Start a session' }).click();
+  await expect(page).toHaveURL(/\/create$/);
+
+  await page.getByLabel('Your name').fill('Coach');
+  await page.getByRole('button', { name: 'Create game' }).click();
+
+  // Code + share link shown.
+  const shareLink = page.getByLabel('Share link');
+  await expect(shareLink).toHaveValue(/\/join\/[A-Z0-9]{6}$/, { timeout: 10_000 });
+  const link = await shareLink.inputValue();
+  const code = link.split('/').pop() as string;
+  await expect(page.getByText(code, { exact: true })).toBeVisible();
+
+  // Facilitation toggle (on by default for the classic template) -> the creator shows
+  // up in the roster tagged as facilitator.
+  await expect(page.getByText('Coach')).toBeVisible();
+  const coachRow = page.locator('li', { hasText: 'Coach' });
+  await expect(coachRow).toContainText('Facilitator');
+
+  // Share link pre-fills the code on a fresh visit.
+  const second = await browser.newContext();
+  const bPage = await second.newPage();
+  await bPage.goto(`/join/${code}`);
+  await expect(bPage.locator('#session-code')).toHaveValue(code);
+
+  await bPage.getByLabel('Display name').fill('Ada');
+  await bPage.getByRole('button', { name: 'Join' }).click();
+
+  // B sees the classic template's config in her own lobby.
+  await expect(bPage.getByRole('heading', { name: 'Leadership Values — 40 → 8 → 3' })).toBeVisible({ timeout: 10_000 });
+  await expect(bPage.getByText('Ada')).toBeVisible();
+
+  await second.close();
+});
+
+test('lobby updateConfig broadcasts to joined participants; startGame locks the designer', async ({ page, browser }) => {
+  await page.goto('/create');
+  await page.getByLabel('Your name').fill('Coach');
+  await page.getByRole('button', { name: 'Create game' }).click();
+
+  const shareLink = page.getByLabel('Share link');
+  await expect(shareLink).toHaveValue(/\/join\/[A-Z0-9]{6}$/, { timeout: 10_000 });
+  const code = (await shareLink.inputValue()).split('/').pop() as string;
+
+  const second = await browser.newContext();
+  const bPage = await second.newPage();
+  await bPage.goto(`/join/${code}`);
+  await bPage.getByLabel('Display name').fill('Ada');
+  await bPage.getByRole('button', { name: 'Join' }).click();
+  await expect(bPage.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+
+  // Creator reopens the designer and renames round 1.
+  await page.getByRole('button', { name: 'Edit game' }).click();
+  const roundName = page.locator('#round-0-name');
+  await roundName.fill('Open triage (renamed)');
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  // B's lobby reflects the change without reloading.
+  await expect(bPage.getByText(/Open triage \(renamed\)/)).toBeVisible({ timeout: 10_000 });
+
+  // Starting the game locks config: the designer controls disappear for the facilitator.
+  await page.getByRole('button', { name: 'Start game' }).click();
+  await expect(page.getByRole('button', { name: 'Edit game' })).toHaveCount(0, { timeout: 10_000 });
+
+  await second.close();
+});

--- a/e2e/join.spec.ts
+++ b/e2e/join.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from '@playwright/test';
  * Full stack against `wrangler dev` (playwright.config.ts runs it as a second
  * webServer, proxied under /api by Vite) — the real Session DO from spec 01.1.
  */
-test('join flow: code + name -> roster contains self', async ({ page }) => {
+test('join flow: code + name -> roster contains self in the lobby', async ({ page }) => {
   await page.goto('/join');
   await page.getByRole('button', { name: /Dev: quick create session/ }).click();
   const codeInput = page.locator('#session-code');
@@ -14,10 +14,11 @@ test('join flow: code + name -> roster contains self', async ({ page }) => {
   await page.getByLabel('Display name').fill('Ada');
   await page.getByRole('button', { name: 'Join' }).click();
 
-  // The join hand-off only redirects once the DO's `state` event has this
-  // participant in `participants` (Join.tsx's JoiningSession effect) — a
-  // successful redirect *is* the roster-contains-self assertion.
-  await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
+  // Spec 03.1: a joined participant lands in the lobby (not the sort route) while the
+  // game is still being configured — the roster showing "Ada" *is* the "contains self"
+  // assertion, directly rather than inferring it from a since-removed redirect.
+  await expect(page.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(code)).toBeVisible();
 
   const token: unknown = await page.evaluate((c) => {
     const raw = localStorage.getItem(`vc:${c}:token`);

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -30,6 +30,11 @@ test('socket-kill: reconnects automatically and a queued intent survives it', as
 
   await page.getByLabel('Display name').fill('Ada');
   await page.getByRole('button', { name: 'Join' }).click();
+
+  // Spec 03.1: joining now lands in the lobby, not directly on /sort — the "quick
+  // create" flow's creator token (same browser) makes Ada the facilitator, so she
+  // starts the game herself to reach the state this test actually cares about.
+  await page.getByRole('button', { name: 'Start game' }).click();
   await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
 
   // Every connection attempt to the session socket fails immediately while this route is

--- a/e2e/rejoin.spec.ts
+++ b/e2e/rejoin.spec.ts
@@ -13,6 +13,11 @@ test('reload on the same join URL resumes silently with the same participant UUI
 
   await page.getByLabel('Display name').fill('Ada');
   await page.getByRole('button', { name: 'Join' }).click();
+
+  // Spec 03.1: joining now lands in the lobby, not directly on /sort — the "quick
+  // create" flow's creator token (same browser) makes Ada the facilitator, so she
+  // starts the game herself to reach the state this test actually cares about.
+  await page.getByRole('button', { name: 'Start game' }).click();
   await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
 
   const originalParticipantId: string = await page.evaluate((c) => {

--- a/party/src/default-config.ts
+++ b/party/src/default-config.ts
@@ -1,14 +1,4 @@
-import type { Deck, GameConfig } from '@values-cards/shared';
-import leadershipForty from '@values-cards/decks/decks/leadership-40.json';
-
-/** `POST /api/session`'s default when no `config` is supplied — the classic 40 → 8 → 3 exercise. */
-export const CLASSIC_TEMPLATE: GameConfig = {
-  title: 'Leadership Values — 40 → 8 → 3',
-  deck: leadershipForty as Deck,
-  rounds: [
-    { name: 'Narrow to 8', keep: 8, rank: false },
-    { name: 'Final 3', keep: 3, rank: true },
-  ],
-  theme: { variant: 'default' },
-  facilitated: true,
-};
+/** `POST /api/session`'s default when no `config` is supplied — the classic 40 → 8 → 3
+ *  exercise. Defined once in `@values-cards/decks` (spec 03.1) so the server fallback
+ *  and the create route's one-tap template can never drift apart. */
+export { CLASSIC_TEMPLATE } from '@values-cards/decks/templates.js';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -47,6 +47,9 @@ importers:
       '@fontsource/fraunces':
         specifier: ^5.3.0
         version: 5.3.0
+      '@values-cards/decks':
+        specifier: workspace:*
+        version: link:../decks
       '@values-cards/shared':
         specifier: workspace:*
         version: link:../shared

--- a/specs/03-config/03.1-game-designer.md
+++ b/specs/03-config/03.1-game-designer.md
@@ -45,24 +45,24 @@ with a full designer behind it. Replaces the 01.2 dev-only quick-create.
 - Facilitator in-game panel → **03.4**.
 
 ## Acceptance criteria
-- [ ] One-tap path E2E `e2e/create.spec.ts`: landing → Start → default template →
+- [x] One-tap path E2E `e2e/create.spec.ts`: landing → Start → default template →
       Create → code + share link shown; second browser joins with the code and sees the
       classic config in its lobby.
-- [ ] Round editor enforces all `validateConfig` rules inline with Create disabled:
+- [x] Round editor enforces all `validateConfig` rules inline with Create disabled:
       component tests cover non-decreasing keeps, keep > deck size, >6 rounds,
       keep-any off round 1, rank off final round
       (`app/src/routes/create/round-editor.test.tsx`).
-- [ ] Switching to a smaller deck flags now-invalid keep-counts immediately
+- [x] Switching to a smaller deck flags now-invalid keep-counts immediately
       (component test).
-- [ ] Lobby `updateConfig` E2E: creator edits rounds while B sits in the lobby → B's
+- [x] Lobby `updateConfig` E2E: creator edits rounds while B sits in the lobby → B's
       lobby reflects the change; after `startGame` the designer is read-only and
       `updateConfig` is rejected (already server-tested in 01.1; E2E asserts the UI).
-- [ ] Facilitation toggle results in `role: 'facilitator'` for the creator in roster
+- [x] Facilitation toggle results in `role: 'facilitator'` for the creator in roster
       (E2E asserts role tag).
-- [ ] Share link `/join/:code` pre-fills the code (E2E).
-- [ ] Designer is fully keyboard operable; all controls labelled (Testing Library
+- [x] Share link `/join/:code` pre-fills the code (E2E).
+- [x] Designer is fully keyboard operable; all controls labelled (Testing Library
       role/name assertions).
-- [ ] `pnpm gate` green.
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -97,7 +97,7 @@
       "depends_on": [
         "01.1"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "03.2",


### PR DESCRIPTION
Implements [specs/03-config/03.1-game-designer.md](specs/03-config/03.1-game-designer.md). Replaces the dev-only "Start a session" stand-in with the real create flow.

## What landed
- **`/create`** — template picker → optional "Customize" designer → one-tap Create.
- **`app/src/routes/lobby.tsx`** — shared by `Create.tsx` and `Join.tsx`: code, share link, roster, and facilitator-only reopen-designer / Start-game.
- **`RoundEditor` / `DeckPicker` / `Designer`** — composed entirely around `shared/validate-config.ts`. No parallel validation logic in the UI (tenet 4).
- `Landing.tsx`'s dev stand-in is now a real link to `/create`.

## Test evidence
`pnpm gate` green, verified independently in a clean install of the worktree:

```
Test Files  33 passed (33)
     Tests  229 passed (229)
  42 passed (34.5s)   [desktop-chromium + mobile-chromium]
```

## ⚠️ Behavior change: the classic template gains its missing first round

`CLASSIC_TEMPLATE` moved from `party/src/default-config.ts` into `decks/templates.ts` (re-exported by party) so the server's `POST /api/session` fallback and the create route's one-tap template share one definition instead of drifting.

In relocating it, the template was **corrected from 2 rounds to 3**:

```
was:  Top 8 (keep 8) → Top 3 (keep 3, ranked)
now:  Open triage (keep any) → Top 8 (keep 8) → Top 3 (keep 3, ranked)
```

The merged 01.1 version was missing the "Open triage" round entirely. I verified this against the spec of record before accepting it — [03.1 lines 15-16](specs/03-config/03.1-game-designer.md#L15) specify the default template as *"Leadership 40 deck, rounds: 'Open triage' keep-any → 'Top 8' → 'Top 3' ranked; matches PRD §4.1"*. So 01.1's `default-config.ts` was the thing out of step with the plan, not this change.

**This changes the default game every new session gets** — three rounds instead of two — so it's worth knowing about even though the spec mandates it.

## Deviations
1. **Join lands in the lobby, not `/sort`.** `Join.tsx` previously redirected straight to the `/sort` demo on any join, which is incompatible with this spec's acceptance criterion that a joiner "sees the classic config in its lobby." Joiners now land in `Lobby` and redirect to `/sort` only once `phase === 'active'`.
2. **Added a "Your name" field to Create.** The spec's field list omitted a display-name input for the creator, but joining requires one; defaulted the same way `Join.tsx` does.

## Tests corrected (verified not loosened)
The join-lands-in-lobby change required updating three E2E specs. I checked each — they're the same strength or stronger:
- **`join.spec.ts`** now asserts the roster shows "Ada" and the code is visible **directly**, rather than inferring roster-contains-self from a since-removed redirect. This is a stronger assertion than before.
- **`rejoin.spec.ts` / `reconnect.spec.ts`** click "Start game" (the quick-create dev flow makes the joiner the facilitator) before asserting the same `/sort` landing they always asserted — preserving exactly what those tests exercise (rejoin identity, reconnect behavior).

## Environment note
Mid-task the e2e stage intermittently reused a stale foreign dev server on the shared pinned ports (8799/5199) from another concurrent worktree. Not a code issue — with ports free, full `pnpm gate` passed cleanly, confirmed twice by the loop and once independently by me. Worth noting that parallel loops contend on those pinned ports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)