### PR TITLE
feat(02.1): Presence & progress

### DIFF
--- a/app/src/components/Avatar.tsx
+++ b/app/src/components/Avatar.tsx
@@ -15,6 +15,7 @@ export function Avatar({ name, hue }: AvatarProps) {
     <div
       role="img"
       aria-label={name}
+      data-hue={hue}
       className="flex h-11 w-11 items-center justify-center rounded-full font-display text-lg font-semibold text-on-accent"
       style={{ backgroundColor: `oklch(55% 0.12 ${hue})` }}
     >

--- a/app/src/components/GatedContinue.test.tsx
+++ b/app/src/components/GatedContinue.test.tsx
@@ -1,0 +1,71 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import { act } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SessionState } from '@values-cards/shared';
+import { createSessionStore, type SessionStoreHook } from '../session/createSessionStore';
+import { GatedContinue } from './GatedContinue';
+
+afterEach(cleanup);
+
+const BASE_STATE: SessionState = {
+  code: 'ABC123',
+  config: {
+    title: 'Test',
+    deck: { name: 'Test deck', cards: [{ value: 'Focus', description: 'd' }] },
+    rounds: [
+      { name: 'Round 1', keep: 1, rank: false },
+      { name: 'Round 2', keep: 1, rank: false },
+    ],
+    theme: { variant: 'default' },
+    facilitated: false,
+  },
+  phase: 'active',
+  participants: {},
+  reveals: {},
+  spotlight: null,
+  gate: { openRound: 1 },
+  processedIntents: {},
+  processedJoins: {},
+};
+
+/** Wires the presentational `GatedContinue` to a live session store — the real shape
+ *  routes/Sort.tsx uses, and what lets this test "drive the store with a patch". */
+function Harness({ useSessionStore, onContinue }: { useSessionStore: SessionStoreHook; onContinue: () => void }) {
+  const gate = useSessionStore((s) => s.state?.gate ?? null);
+  return <GatedContinue gate={gate} nextRound={2} onContinue={onContinue} />;
+}
+
+describe('GatedContinue', () => {
+  it('blocks Continue and shows the waiting notice while the gate has not opened the next round', () => {
+    const store = createSessionStore();
+    store.getState().applyEvent({ type: 'state', state: BASE_STATE });
+
+    render(<Harness useSessionStore={store} onContinue={vi.fn()} />);
+
+    expect(screen.getByRole('status').textContent).toBe('Waiting for Round 2 to open');
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(true);
+  });
+
+  it('unblocks Continue once a `setGate` patch opens the round', () => {
+    const store = createSessionStore();
+    store.getState().applyEvent({ type: 'state', state: BASE_STATE });
+
+    render(<Harness useSessionStore={store} onContinue={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(true);
+
+    act(() => {
+      store.getState().applyEvent({ type: 'patch', patch: { gate: { openRound: 2 } } });
+    });
+
+    expect(screen.queryByRole('status')).toBeNull();
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(false);
+  });
+
+  it('is never gated when no gate is set', () => {
+    const store = createSessionStore();
+    store.getState().applyEvent({ type: 'state', state: { ...BASE_STATE, gate: null } });
+
+    render(<Harness useSessionStore={store} onContinue={vi.fn()} />);
+    expect(screen.getByRole('button', { name: 'Continue' }).hasAttribute('disabled')).toBe(false);
+  });
+});

--- a/app/src/components/GatedContinue.tsx
+++ b/app/src/components/GatedContinue.tsx
@@ -1,0 +1,26 @@
+import type { SessionState } from '@values-cards/shared';
+import { Button } from './Button';
+
+export interface GatedContinueProps {
+  gate: SessionState['gate'];
+  /** The round the participant is about to advance into. */
+  nextRound: number;
+  onContinue: () => void;
+}
+
+/**
+ * The round-complete interstitial's Continue button, blocked while the facilitator's
+ * `gate` hasn't opened `nextRound` yet (spec 02.1; the gate control itself is 03.4).
+ */
+export function GatedContinue({ gate, nextRound, onContinue }: GatedContinueProps) {
+  const blocked = gate !== null && nextRound > gate.openRound;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {blocked ? <p role="status">Waiting for Round {nextRound} to open</p> : null}
+      <Button onClick={onContinue} disabled={blocked}>
+        Continue
+      </Button>
+    </div>
+  );
+}

--- a/app/src/components/Roster.test.tsx
+++ b/app/src/components/Roster.test.tsx
@@ -1,0 +1,70 @@
+import { cleanup, fireEvent, render, screen, within } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Participant } from '@values-cards/shared';
+import { Roster } from './Roster';
+
+afterEach(cleanup);
+
+function participants(): Record<string, Participant> {
+  return {
+    a1: {
+      name: 'Ada',
+      avatarHue: 120,
+      role: 'facilitator',
+      connected: true,
+      progress: { round: 2, sorted: 14, kept: 5, done: false },
+    },
+    b2: {
+      name: 'Bea',
+      avatarHue: 240,
+      role: 'participant',
+      connected: false,
+      progress: { round: 1, sorted: 0, kept: 0, done: true },
+    },
+  };
+}
+
+describe('Roster', () => {
+  it('renders an accessible list with names, roles, progress, and connection status', () => {
+    render(<Roster participants={participants()} selfId="a1" />);
+
+    const list = screen.getByRole('list', { name: 'Participants' });
+    const items = within(list).getAllByRole('listitem');
+    expect(items).toHaveLength(2);
+
+    expect(within(items[0]!).getByText(/Ada/)).toBeTruthy();
+    expect(within(items[0]!).getByText(/\(you\)/)).toBeTruthy();
+    expect(within(items[0]!).getByText(/Facilitator/)).toBeTruthy();
+    expect(within(items[0]!).getByText('Round 2 · 14 sorted · 5 kept')).toBeTruthy();
+    expect(within(items[0]!).getByText('Connected')).toBeTruthy();
+
+    expect(within(items[1]!).getByText(/Bea/)).toBeTruthy();
+    expect(within(items[1]!).queryByText(/\(you\)/)).toBeNull();
+    expect(within(items[1]!).getByText('Done ✓')).toBeTruthy();
+    expect(within(items[1]!).getByText('Disconnected')).toBeTruthy();
+  });
+
+  it('never renders card data — only counts', () => {
+    render(<Roster participants={participants()} selfId="a1" />);
+    // The roster's own text should only ever contain names/roles/counts, so this is a
+    // structural sanity check that nothing here comes from deck content.
+    expect(screen.queryByText(/Card|Caffeine|Snacks/)).toBeNull();
+  });
+
+  it('is sorted by join order (object insertion order)', () => {
+    render(<Roster participants={participants()} selfId="a1" />);
+    const names = screen.getAllByRole('listitem').map((li) => li.textContent ?? '');
+    expect(names[0]).toMatch(/Ada/);
+    expect(names[1]).toMatch(/Bea/);
+  });
+
+  it('collapsible: starts as an avatar strip and expands into the full list on click', () => {
+    render(<Roster participants={participants()} selfId="a1" collapsible />);
+    expect(screen.queryByRole('list', { name: 'Participants' })).toBeNull();
+
+    const toggle = screen.getByRole('button', { name: /Show participants/ });
+    fireEvent.click(toggle);
+
+    expect(screen.getByRole('list', { name: 'Participants' })).toBeTruthy();
+  });
+});

--- a/app/src/components/Roster.tsx
+++ b/app/src/components/Roster.tsx
@@ -1,0 +1,86 @@
+import { useState } from 'react';
+import type { Participant } from '@values-cards/shared';
+import { Avatar } from './Avatar';
+
+export interface RosterProps {
+  /** `SessionState.participants` — object key order is insertion order (join order, decision). */
+  participants: Record<string, Participant>;
+  selfId: string;
+  /** Renders as a collapsed avatar strip with an expand toggle (sort/wall); omit for the
+   *  always-expanded lobby view. */
+  collapsible?: boolean;
+}
+
+function progressLine(participant: Participant): string {
+  if (participant.progress.done) return 'Done ✓';
+  const { round, sorted, kept } = participant.progress;
+  return `Round ${round} · ${sorted} sorted · ${kept} kept`;
+}
+
+function RosterList({ participants, selfId }: Pick<RosterProps, 'participants' | 'selfId'>) {
+  const ids = Object.keys(participants);
+  return (
+    <ul aria-label="Participants" className="flex flex-col gap-2">
+      {ids.map((id) => {
+        const participant = participants[id];
+        if (!participant) return null;
+        return (
+          <li key={id} className="flex items-center gap-3">
+            <Avatar name={participant.name} hue={participant.avatarHue} />
+            <div className="flex flex-col">
+              <span className="font-semibold text-ink">
+                {participant.name}
+                {id === selfId ? ' (you)' : ''}
+                {participant.role === 'facilitator' ? ' · Facilitator' : ''}
+              </span>
+              <span className="text-sm text-ink-muted">{progressLine(participant)}</span>
+            </div>
+            <span
+              data-connected={participant.connected}
+              aria-hidden="true"
+              className={`ml-auto h-2.5 w-2.5 rounded-full border border-ink-muted ${participant.connected ? 'bg-accent' : 'bg-transparent'}`}
+            />
+            <span className="sr-only">{participant.connected ? 'Connected' : 'Disconnected'}</span>
+          </li>
+        );
+      })}
+    </ul>
+  );
+}
+
+/**
+ * Participants visible to each other — names, avatars, progress counts, connection —
+ * without ever rendering card contents (the client only ever has counts, spec 02.1).
+ */
+export function Roster({ participants, selfId, collapsible = false }: RosterProps) {
+  const [expanded, setExpanded] = useState(!collapsible);
+
+  if (!collapsible || expanded) {
+    return (
+      <div>
+        {collapsible ? (
+          <button type="button" onClick={() => setExpanded(false)} className="mb-2 text-sm font-semibold text-ink-muted">
+            Hide participants
+          </button>
+        ) : null}
+        <RosterList participants={participants} selfId={selfId} />
+      </div>
+    );
+  }
+
+  const ids = Object.keys(participants);
+  return (
+    <button
+      type="button"
+      onClick={() => setExpanded(true)}
+      aria-label={`Show participants (${ids.length})`}
+      className="flex items-center -space-x-2"
+    >
+      {ids.map((id) => {
+        const participant = participants[id];
+        if (!participant) return null;
+        return <Avatar key={id} name={participant.name} hue={participant.avatarHue} />;
+      })}
+    </button>
+  );
+}

--- a/app/src/routes/Join.tsx
+++ b/app/src/routes/Join.tsx
@@ -2,7 +2,7 @@ import { useEffect, useRef, useState, type FormEvent } from 'react';
 import { Button } from '../components/Button';
 import { ConnectionPill } from '../session/ConnectionPill';
 import { intents } from '../session/intents';
-import { loadToken } from '../session/tokens';
+import { loadToken, saveCurrentCode } from '../session/tokens';
 import { useSession } from '../session/useSession';
 import { Lobby } from './lobby';
 
@@ -112,12 +112,25 @@ function JoiningSession({ code, name }: { code: string; name: string }) {
 
   useEffect(() => {
     const token = loadToken(code);
-    if (!token || !state) return;
+    // Gating on `connection === 'live'` (not just `state` presence) matters: 'live' is the
+    // same transition that just flushed the offline intent queue (useSession.ts), and
+    // `ws.send()` only hands a frame to the network stack — it doesn't block until the
+    // frame is actually transmitted. Navigating away too soon after a flush can tear the
+    // page down mid-transmission and silently drop it (spec 02.1's e2e/reconnect.spec.ts
+    // caught this losing a queued `reportProgress`); a short delay gives the browser time
+    // to actually get the flushed frame(s) onto the wire before the document unloads.
+    // TODO: the delay becomes unnecessary once a client-side router replaces the full
+    // document navigation here — there's no teardown to race then.
+    if (!token || !state || connection !== 'live') return;
+    // 03.1: participants wait in the lobby while the game is configured; only an `active`
+    // phase hands off to the sort route.
     if (state.phase === 'active') {
-      // 01.3/01.4 own the real sort route; this is the placeholder hand-off (out of scope here).
-      window.location.assign('/sort');
+      // `/sort` reads this to resume the real joined session (02.1) instead of its
+      // standalone local demo — see routes/Sort.tsx.
+      saveCurrentCode(code);
+      setTimeout(() => window.location.assign('/sort'), 100);
     }
-  }, [state, code]);
+  }, [state, code, connection]);
 
   const token = loadToken(code);
   if (state && token && state.participants[token.participantId]) {

--- a/app/src/routes/Join.tsx
+++ b/app/src/routes/Join.tsx
@@ -122,9 +122,10 @@ function JoiningSession({ code, name }: { code: string; name: string }) {
     // TODO: the delay becomes unnecessary once a client-side router replaces the full
     // document navigation here — there's no teardown to race then.
     if (!token || !state || connection !== 'live') return;
-    // 03.1: participants wait in the lobby while the game is configured; only an `active`
-    // phase hands off to the sort route.
-    if (state.phase === 'active') {
+    // 02.1 owns the pre-start participant experience and places the lobby in `routes/Sort`'s
+    // pre-start state, so a joined participant hands off to /sort immediately and waits
+    // there. 03.1's `routes/lobby` remains the *creator's* lobby on /create.
+    if (state.participants[token.participantId]) {
       // `/sort` reads this to resume the real joined session (02.1) instead of its
       // standalone local demo — see routes/Sort.tsx.
       saveCurrentCode(code);

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -1,16 +1,24 @@
-import { useMemo } from 'react';
-import { GameConfigSchema, type Card, type GameConfig } from '@values-cards/shared';
+import { useEffect, useMemo, useRef } from 'react';
+import { GameConfigSchema, type Card, type GameConfig, type SessionState } from '@values-cards/shared';
 import { Button } from '../components/Button';
 import { GameCard } from '../components/GameCard';
+import { GatedContinue } from '../components/GatedContinue';
+import { Roster } from '../components/Roster';
 import { RankBoard } from '../engine-ui/RankBoard';
 import { SortRound } from '../engine-ui/SortRound';
 import { TrimGrid } from '../engine-ui/TrimGrid';
-import { createSortStore, getPhase } from '../stores/createSortStore';
+import { intents } from '../session/intents';
+import { computeProgress, createMilestoneReporter } from '../session/milestones';
+import { loadCurrentCode, loadToken } from '../session/tokens';
+import { ConnectionPill } from '../session/ConnectionPill';
+import type { UseSessionResult } from '../session/useSession';
+import { useSession } from '../session/useSession';
+import { createSortStore, getPhase, type SortStoreHook } from '../stores/createSortStore';
 
-// Placeholder session identity until 01.2 (client session layer) wires a
-// real join flow. The sort loop itself is fully local and config-driven —
-// this route just needs *some* session code + participant id + config to
-// demonstrate it.
+// Placeholder session identity for the standalone local demo below (no join, no DO) —
+// this predates 01.2's real client session layer and is kept only so the existing demo
+// journeys (solo-journey, sort-*, round-flow-refresh) keep exercising the sort loop
+// in isolation. A real joined session (Join.tsx) takes the `SessionSort` path instead.
 const SESSION_CODE = 'DEMO01';
 const PARTICIPANT_ID_KEY = 'vc:demo:participantId';
 
@@ -63,6 +71,202 @@ function cardsInOrder(ids: string[], byId: Map<string, Card>): Card[] {
  * flow, never separate pages/routes.
  */
 export function Sort() {
+  const code = loadCurrentCode();
+  return code ? <SessionSort code={code} /> : <DemoSort />;
+}
+
+/** A real joined session (02.1): lobby, roster, milestone reporting, gated rounds. */
+function SessionSort({ code }: { code: string }) {
+  const token = useMemo(() => loadToken(code), [code]);
+  const { state, connection, send } = useSession(code);
+
+  useEffect(() => {
+    if (!token) window.location.assign(`/join/${code}`);
+  }, [token, code]);
+
+  if (!token || !state) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-surface text-ink">
+        <ConnectionPill connection={connection} />
+        <p>Loading…</p>
+      </main>
+    );
+  }
+
+  const me = state.participants[token.participantId];
+  if (!me) {
+    return (
+      <main className="flex min-h-screen items-center justify-center bg-surface text-ink">
+        <ConnectionPill connection={connection} />
+        <p>Loading…</p>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <ConnectionPill connection={connection} />
+      {state.phase === 'lobby' ? (
+        <Lobby state={state} participantId={token.participantId} send={send} />
+      ) : (
+        <ActiveSort code={code} participantId={token.participantId} config={state.config} state={state} send={send} />
+      )}
+    </>
+  );
+}
+
+function Lobby({ state, participantId, send }: { state: SessionState; participantId: string; send: UseSessionResult['send'] }) {
+  const me = state.participants[participantId];
+  const canStart = !state.config.facilitated || me?.role === 'facilitator';
+
+  return (
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface p-8 text-ink">
+      <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
+      <p className="text-ink-muted">Waiting to start · code {state.code}</p>
+      <Roster participants={state.participants} selfId={participantId} />
+      <Button onClick={() => send(intents.startGame(participantId))} disabled={!canStart} title={canStart ? undefined : 'Only the facilitator can start this game'}>
+        Start game
+      </Button>
+    </main>
+  );
+}
+
+function ActiveSort({
+  code,
+  participantId,
+  config,
+  state,
+  send,
+}: {
+  code: string;
+  participantId: string;
+  config: GameConfig;
+  state: SessionState;
+  send: UseSessionResult['send'];
+}) {
+  const useSortStore = useMemo(() => createSortStore(code, participantId, config), [code, participantId, config]);
+  const sortState = useSortStore();
+  const phase = getPhase(sortState, config);
+  const byId = useMemo(() => new Map(config.deck.cards.map((card) => [card.value, card])), [config]);
+
+  // Milestones (invariant 2: counts only, never card ids/values) — debounced 500ms
+  // trailing so a swipe burst collapses into one intent, flowing through 01.2's
+  // offline queue like any other `send`.
+  const sendRef = useRef(send);
+  sendRef.current = send;
+  useEffect(() => {
+    const reporter = createMilestoneReporter((progress) => {
+      sendRef.current(intents.reportProgress(participantId, progress.round, progress.sorted, progress.kept, progress.done));
+    });
+    reporter.report(computeProgress(useSortStore.getState(), config));
+    const unsubscribe = useSortStore.subscribe((next) => reporter.report(computeProgress(next, config)));
+    return () => {
+      unsubscribe();
+      reporter.cancel();
+    };
+  }, [useSortStore, config, participantId]);
+
+  return (
+    <>
+      <div className="fixed right-4 top-4 z-toast">
+        <Roster participants={state.participants} selfId={participantId} collapsible />
+      </div>
+      <SortBody config={config} useSortStore={useSortStore} phase={phase} byId={byId} gate={state.gate} />
+    </>
+  );
+}
+
+function SortBody({
+  config,
+  useSortStore,
+  phase,
+  byId,
+  gate,
+}: {
+  config: GameConfig;
+  useSortStore: SortStoreHook;
+  phase: ReturnType<typeof getPhase>;
+  byId: Map<string, Card>;
+  gate: SessionState['gate'];
+}) {
+  const state = useSortStore();
+
+  if (phase === 'sort') {
+    return <SortRound config={config} useSortStore={useSortStore} />;
+  }
+
+  if (phase === 'round-complete') {
+    const roundCfg = config.rounds[state.round - 1];
+    const setAside = state.totalDiscarded + state.discarded.length;
+    return (
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-center text-ink">
+        <h1 className="font-display text-2xl font-semibold">{roundCfg?.name} complete</h1>
+        <p className="text-ink-muted">
+          {state.kept.length} kept · {setAside} set aside
+        </p>
+        <GatedContinue gate={gate} nextRound={state.round + 1} onContinue={() => useSortStore.getState().continueRound()} />
+      </main>
+    );
+  }
+
+  if (phase === 'trim') {
+    const roundCfg = config.rounds[state.round - 1];
+    const limit = typeof roundCfg?.keep === 'number' ? roundCfg.keep : 0;
+    return (
+      <TrimGrid
+        cards={cardsInOrder(state.kept, byId)}
+        cut={state.cut}
+        limit={limit}
+        onToggleCut={(cardId) => useSortStore.getState().toggleCut(cardId)}
+        onConfirm={() => useSortStore.getState().confirmTrim()}
+      />
+    );
+  }
+
+  if (phase === 'rank') {
+    return (
+      <RankBoard
+        cards={cardsInOrder(state.ranking ?? state.kept, byId)}
+        onReorder={(order) => useSortStore.getState().setRanking(order)}
+        onConfirm={() => useSortStore.getState().confirmRank()}
+      />
+    );
+  }
+
+  // result — local-only plaque preview; reveal (02.2), wall (02.3) and
+  // export (04.1) build on this later.
+  const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
+  const isRanked = config.rounds[config.rounds.length - 1]?.rank === true;
+  return (
+    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+      <h1 className="font-display text-2xl font-semibold">{config.title}</h1>
+      <p className="text-ink-muted">Your final cards</p>
+      <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+        {finalCards.map((card, index) => (
+          <li key={card.value} className="flex flex-col items-center gap-2">
+            {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
+            <GameCard title={card.value} description={card.description} size="md" />
+          </li>
+        ))}
+      </ol>
+      <div className="flex gap-4">
+        <Button variant="secondary" disabled title="Coming soon">
+          Reveal
+        </Button>
+        <Button variant="secondary" disabled title="Coming soon">
+          Download
+        </Button>
+      </div>
+    </main>
+  );
+}
+
+/**
+ * Standalone local demo (predates 01.2/02.1): no join, no DO, no roster — just the
+ * config-driven sort loop for `/sort` visited directly. Byte-for-byte the previous
+ * `Sort()` body, so the 01.3/01.4 acceptance journeys keep passing unchanged.
+ */
+function DemoSort() {
   const useSortStore = useMemo(() => {
     const participantId = getDemoParticipantId();
     return createSortStore(SESSION_CODE, participantId, DEMO_CONFIG);

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -123,6 +123,17 @@ function Lobby({ state, participantId, send }: { state: SessionState; participan
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
       <p className="text-ink-muted">Waiting to start · code {state.code}</p>
+      {/* 03.1 requires a joined participant to see the game's config in its lobby, and to
+          see facilitator `updateConfig` edits arrive live. This is that lobby — 02.1 owns
+          the pre-start participant experience, so there is one lobby, not two. */}
+      <ol aria-label="Rounds" className="flex flex-col gap-1 text-center text-sm text-ink-muted">
+        {state.config.rounds.map((round, index) => (
+          <li key={`${index}-${round.name}`}>
+            {round.name} · {round.keep === 'any' ? 'keep any' : `keep ${round.keep}`}
+            {round.rank ? ' · ranked' : ''}
+          </li>
+        ))}
+      </ol>
       <Roster participants={state.participants} selfId={participantId} />
       <Button onClick={() => send(intents.startGame(participantId))} disabled={!canStart} title={canStart ? undefined : 'Only the facilitator can start this game'}>
         Start game

--- a/app/src/session/milestones.test.ts
+++ b/app/src/session/milestones.test.ts
@@ -1,0 +1,90 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import type { GameConfig } from '@values-cards/shared';
+import { computeProgress, createMilestoneReporter } from './milestones';
+import { createSortStore } from '../stores/createSortStore';
+
+function config(): GameConfig {
+  return {
+    title: 'Test',
+    deck: {
+      name: 'Deck',
+      cards: Array.from({ length: 10 }, (_, i) => ({ value: `Card ${i}`, description: `Desc ${i}` })),
+    },
+    rounds: [{ name: 'Round 1', keep: 10, rank: false }],
+    theme: { variant: 'default' },
+    facilitated: false,
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  localStorage.clear();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('createMilestoneReporter', () => {
+  it('collapses a rapid burst into a single send with the final counts', () => {
+    const send = vi.fn();
+    const reporter = createMilestoneReporter(send, 500);
+
+    for (let i = 1; i <= 10; i++) {
+      reporter.report({ round: 1, sorted: i, kept: i, done: false });
+      vi.advanceTimersByTime(50); // faster than the 500ms trailing window
+    }
+
+    expect(send).not.toHaveBeenCalled();
+    vi.advanceTimersByTime(500);
+    expect(send).toHaveBeenCalledTimes(1);
+    expect(send).toHaveBeenCalledWith({ round: 1, sorted: 10, kept: 10, done: false });
+  });
+
+  it('sends again after a quiet period followed by more activity', () => {
+    const send = vi.fn();
+    const reporter = createMilestoneReporter(send, 500);
+
+    reporter.report({ round: 1, sorted: 1, kept: 1, done: false });
+    vi.advanceTimersByTime(500);
+    expect(send).toHaveBeenCalledTimes(1);
+
+    reporter.report({ round: 1, sorted: 2, kept: 2, done: false });
+    vi.advanceTimersByTime(500);
+    expect(send).toHaveBeenCalledTimes(2);
+  });
+
+  it('cancel drops a pending send', () => {
+    const send = vi.fn();
+    const reporter = createMilestoneReporter(send, 500);
+    reporter.report({ round: 1, sorted: 1, kept: 1, done: false });
+    reporter.cancel();
+    vi.advanceTimersByTime(500);
+    expect(send).not.toHaveBeenCalled();
+  });
+});
+
+describe('computeProgress', () => {
+  it('reports counts only — never card ids/values', () => {
+    const cfg = config();
+    const store = createSortStore('CODE01', 'participant-1', cfg);
+    store.getState().keep(store.getState().queue[0] as string);
+    store.getState().keep(store.getState().queue[0] as string);
+    store.getState().discard(store.getState().queue[0] as string);
+
+    const progress = computeProgress(store.getState(), cfg);
+    expect(progress).toEqual({ round: 1, sorted: 3, kept: 2, done: false });
+    expect(Object.values(progress).some((v) => typeof v === 'string')).toBe(false);
+  });
+
+  it('marks done once the round (and game) is complete', () => {
+    const cfg = config();
+    const store = createSortStore('CODE02', 'participant-2', cfg);
+    while (store.getState().queue.length > 0) {
+      store.getState().keep(store.getState().queue[0] as string);
+    }
+
+    const progress = computeProgress(store.getState(), cfg);
+    expect(progress.done).toBe(true);
+  });
+});

--- a/app/src/session/milestones.ts
+++ b/app/src/session/milestones.ts
@@ -1,0 +1,47 @@
+import type { GameConfig, Progress } from '@values-cards/shared';
+import { getPhase, type SortState } from '../stores/createSortStore';
+
+const DEBOUNCE_MS = 500;
+
+/**
+ * Counts only (invariant 2) — round, cards processed this round, cards kept this round,
+ * and whether the whole game is finished. Never the card ids/values themselves.
+ */
+export function computeProgress(state: SortState, config: GameConfig): Progress {
+  return {
+    round: state.round,
+    sorted: state.kept.length + state.discarded.length,
+    kept: state.kept.length,
+    done: getPhase(state, config) === 'result',
+  };
+}
+
+export interface MilestoneReporter {
+  /** Schedules `send` with the latest progress, debounced (trailing) so a swipe burst
+   *  collapses into one intent. */
+  report: (progress: Progress) => void;
+  /** Cancels any pending debounced send (e.g. on unmount). */
+  cancel: () => void;
+}
+
+/** `send` is fired at most once per `delayMs` of inactivity, always with the *latest*
+ *  progress passed to `report` — never an intermediate one. */
+export function createMilestoneReporter(send: (progress: Progress) => void, delayMs = DEBOUNCE_MS): MilestoneReporter {
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  let pending: Progress | undefined;
+
+  return {
+    report(progress) {
+      pending = progress;
+      clearTimeout(timer);
+      timer = setTimeout(() => {
+        if (pending) send(pending);
+        pending = undefined;
+      }, delayMs);
+    },
+    cancel() {
+      clearTimeout(timer);
+      pending = undefined;
+    },
+  };
+}

--- a/app/src/session/tokens.ts
+++ b/app/src/session/tokens.ts
@@ -43,3 +43,15 @@ export function saveToken(code: string, token: StoredToken): void {
 export function clearToken(code: string): void {
   localStorage.removeItem(storageKey(code));
 }
+
+const CURRENT_CODE_KEY = 'vc:currentCode';
+
+/** The most recently joined session code, so a hand-off to a fixed route (e.g. `/sort`)
+ *  can resume the real session without carrying the code in the URL (02.1). */
+export function saveCurrentCode(code: string): void {
+  localStorage.setItem(CURRENT_CODE_KEY, code);
+}
+
+export function loadCurrentCode(): string | null {
+  return localStorage.getItem(CURRENT_CODE_KEY);
+}

--- a/e2e/presence-connection.spec.ts
+++ b/e2e/presence-connection.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+declare global {
+  interface Window {
+    __VC_TEST__?: {
+      send: (intent: Record<string, unknown>) => void;
+      getState: () => unknown;
+      closeSocket: () => void;
+    };
+  }
+}
+
+const WS_PATTERN = /\/api\/session\//;
+
+/**
+ * Two browsers, same session: A's connection dot on B's roster flips hollow within 5s of
+ * A dropping, and fills back in once A rejoins (spec 02.1's connection dot criterion).
+ * Arms `routeWebSocket` to fail every reconnect attempt while observing the disconnected
+ * state — same technique as `e2e/reconnect.spec.ts` — so the transient isn't a race against
+ * `wrangler dev`'s (sub-network-round-trip) resume time.
+ */
+test('presence-connection: A dropping flips A hollow on B, rejoin fills it back in', async ({ browser }) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  await pageA.goto('/join');
+  await pageA.getByRole('button', { name: /Dev: quick create session/ }).click();
+  const codeInput = pageA.locator('#session-code');
+  await expect(codeInput).toHaveValue(/^[A-Z0-9]{6}$/, { timeout: 5000 });
+  const code = await codeInput.inputValue();
+
+  await pageA.getByLabel('Display name').fill('Ada');
+  await pageA.getByRole('button', { name: 'Join' }).click();
+  await expect(pageA).toHaveURL(/\/sort$/, { timeout: 10_000 });
+
+  await pageB.goto(`/join/${code}`);
+  await pageB.getByLabel('Display name').fill('Bea');
+  await pageB.getByRole('button', { name: 'Join' }).click();
+  await expect(pageB).toHaveURL(/\/sort$/, { timeout: 10_000 });
+
+  const adaDot = pageB.getByRole('listitem').filter({ hasText: 'Ada' }).locator('[data-connected]');
+  await expect(adaDot).toHaveAttribute('data-connected', 'true', { timeout: 10_000 });
+
+  // Fail every reconnect attempt from here so "disconnected" is stable, not a transient window.
+  await pageA.routeWebSocket(WS_PATTERN, (ws) => {
+    ws.close({ code: 1006, reason: 'e2e: simulated drop' });
+  });
+  await pageA.waitForFunction(() => Boolean(window.__VC_TEST__), { timeout: 10_000 });
+  await pageA.evaluate(() => window.__VC_TEST__?.closeSocket());
+
+  await expect(adaDot).toHaveAttribute('data-connected', 'false', { timeout: 5000 });
+
+  // Let the next reconnect attempt through — A rejoins for real.
+  await pageA.routeWebSocket(WS_PATTERN, (ws) => {
+    ws.connectToServer();
+  });
+
+  await expect(adaDot).toHaveAttribute('data-connected', 'true', { timeout: 20_000 });
+
+  await contextA.close();
+  await contextB.close();
+});

--- a/e2e/presence.spec.ts
+++ b/e2e/presence.spec.ts
@@ -1,0 +1,140 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/**
+ * A deliberately tiny deck (4 cards, 1 round, keep 2, non-facilitated) so a full round
+ * — join through result — is a handful of keypresses, not forty. `facilitated: false`
+ * exercises the 02.1 lobby rule: any participant may start.
+ */
+const CUSTOM_CONFIG = {
+  title: 'Presence E2E',
+  deck: {
+    name: 'Mini',
+    cards: [
+      { value: 'Alpha', description: 'The first mini-deck value, never sent unrevealed' },
+      { value: 'Beta', description: 'The second mini-deck value, never sent unrevealed' },
+      { value: 'Gamma', description: 'The third mini-deck value, never sent unrevealed' },
+      { value: 'Delta', description: 'The fourth mini-deck value, never sent unrevealed' },
+    ],
+  },
+  rounds: [{ name: 'Round 1', keep: 2, rank: false }],
+  theme: { variant: 'default' },
+  facilitated: false,
+};
+
+const CARD_NEEDLES = CUSTOM_CONFIG.deck.cards.flatMap((card) => [card.value, card.description]);
+
+/** The deck listing itself is public config, not a participant's unrevealed choice —
+ *  strip it before scanning a frame for card leakage (invariant 1 is about choices, not
+ *  the shared config every client legitimately receives). */
+function stripConfig(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(stripConfig);
+  if (value && typeof value === 'object') {
+    return Object.fromEntries(
+      Object.entries(value as Record<string, unknown>)
+        .filter(([key]) => key !== 'config')
+        .map(([key, v]) => [key, stripConfig(v)]),
+    );
+  }
+  return value;
+}
+
+function assertNoCardLeak(frames: string[], label: string) {
+  for (const raw of frames) {
+    let payload: unknown;
+    try {
+      payload = JSON.parse(raw);
+    } catch {
+      continue; // not JSON — can't be a card leak
+    }
+    const scrubbed = JSON.stringify(stripConfig(payload));
+    for (const needle of CARD_NEEDLES) {
+      expect(scrubbed, `${label} frame leaked "${needle}": ${raw}`).not.toContain(needle);
+    }
+  }
+}
+
+function collectFrames(page: Page): string[] {
+  const frames: string[] = [];
+  page.on('websocket', (ws) => {
+    ws.on('framereceived', (f) => frames.push(typeof f.payload === 'string' ? f.payload : f.payload.toString('utf8')));
+    ws.on('framesent', (f) => frames.push(typeof f.payload === 'string' ? f.payload : f.payload.toString('utf8')));
+  });
+  return frames;
+}
+
+async function joinAs(page: Page, code: string, name: string, creatorToken?: string) {
+  await page.goto(`/join/${code}`);
+  if (creatorToken) {
+    await page.evaluate(
+      ({ code: c, token }) => sessionStorage.setItem(`vc:${c}:creatorToken`, token),
+      { code, token: creatorToken },
+    );
+  }
+  await page.getByLabel('Display name').fill(name);
+  await page.getByRole('button', { name: 'Join' }).click();
+  await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
+}
+
+test('presence: roster membership, live progress, done, matching avatar hue, no card leakage', async ({ browser, request }) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+  const framesA = collectFrames(pageA);
+  const framesB = collectFrames(pageB);
+
+  const created = await (
+    await request.post('/api/session', { data: { config: CUSTOM_CONFIG } })
+  ).json() as { code: string; creatorToken: string };
+
+  await joinAs(pageA, created.code, 'Ada', created.creatorToken);
+
+  // B sees A appear in the roster on join (both still in the lobby).
+  await joinAs(pageB, created.code, 'Bea');
+  await expect(pageB.getByRole('listitem').filter({ hasText: 'Ada' })).toBeVisible({ timeout: 10_000 });
+  await expect(pageA.getByRole('listitem').filter({ hasText: 'Bea' })).toBeVisible({ timeout: 10_000 });
+
+  const adaHueOnB = await pageB
+    .getByRole('listitem')
+    .filter({ hasText: 'Ada' })
+    .getByRole('img')
+    .first()
+    .getAttribute('data-hue');
+
+  // Non-facilitated game: any participant (here, Ada) may start.
+  await pageA.getByRole('button', { name: 'Start game' }).click();
+  await expect(pageA.getByText('4 left')).toBeVisible({ timeout: 10_000 });
+
+  // B expands the collapsed roster strip to watch progress during sort.
+  await pageB.getByRole('button', { name: /Show participants/ }).click();
+  const adaRowOnB = pageB.getByRole('listitem').filter({ hasText: 'Ada' });
+  const adaHueDuringSort = await adaRowOnB.getByRole('img').first().getAttribute('data-hue');
+  expect(adaHueDuringSort).toBe(adaHueOnB);
+
+  // A sorts the whole (tiny) round: keep 2, discard 2 — no trim/rank, straight to result.
+  // Each press's swipe-exit animation must resolve (SwipeCard.commit) before the next card
+  // mounts and re-focuses itself, so waiting on the "N left" counter between presses avoids
+  // a keypress landing while no card is focused (same pattern as solo-journey.spec.ts).
+  await pageA.keyboard.press('ArrowRight'); // keep
+  await expect(pageA.getByText('3 left')).toBeVisible({ timeout: 5000 });
+  await expect(adaRowOnB).toContainText('1 sorted', { timeout: 10_000 });
+  await pageA.keyboard.press('ArrowLeft'); // discard
+  await expect(pageA.getByText('2 left')).toBeVisible({ timeout: 5000 });
+  await pageA.keyboard.press('ArrowRight'); // keep
+  await expect(pageA.getByText('1 left')).toBeVisible({ timeout: 5000 });
+  await pageA.keyboard.press('ArrowLeft'); // discard
+
+  await expect(pageA.getByRole('heading', { name: 'Presence E2E' })).toBeVisible({ timeout: 10_000 });
+  await expect(adaRowOnB).toContainText('Done ✓', { timeout: 10_000 });
+
+  // Invariant 1, end to end: every frame either side ever sent/received, and the DO's own
+  // persisted storage, contain no card value/description outside the public deck config.
+  assertNoCardLeak(framesA, 'A');
+  assertNoCardLeak(framesB, 'B');
+
+  const dump = await (await request.get(`/api/session/${created.code}/dump`)).json();
+  assertNoCardLeak([JSON.stringify(dump)], 'DO storage');
+
+  await contextA.close();
+  await contextB.close();
+});

--- a/e2e/reconnect.spec.ts
+++ b/e2e/reconnect.spec.ts
@@ -72,3 +72,69 @@ test('socket-kill: reconnects automatically and a queued intent survives it', as
   await expect(page.getByRole('status').filter({ hasText: 'Reconnecting' })).toHaveCount(0, { timeout: 20_000 });
   await expect(page).toHaveURL(/\/sort$/, { timeout: 20_000 });
 });
+
+/**
+ * Spec 02.1: milestones sent while offline aren't lost — they queue (01.2) and flush on
+ * resume, so a second participant watching the roster eventually sees the same counts.
+ */
+test('presence: offline-sorted progress arrives on B once A reconnects', async ({ browser }) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  await pageA.goto('/join');
+  await pageA.getByRole('button', { name: /Dev: quick create session/ }).click();
+  const codeInput = pageA.locator('#session-code');
+  await expect(codeInput).toHaveValue(/^[A-Z0-9]{6}$/, { timeout: 5000 });
+  const code = await codeInput.inputValue();
+
+  await pageA.getByLabel('Display name').fill('Ada');
+  await pageA.getByRole('button', { name: 'Join' }).click();
+  await expect(pageA).toHaveURL(/\/sort$/, { timeout: 10_000 });
+
+  await pageB.goto(`/join/${code}`);
+  await pageB.getByLabel('Display name').fill('Bea');
+  await pageB.getByRole('button', { name: 'Join' }).click();
+  await expect(pageB).toHaveURL(/\/sort$/, { timeout: 10_000 });
+
+  const adaRowOnB = pageB.getByRole('listitem').filter({ hasText: 'Ada' });
+  await expect(adaRowOnB).toBeVisible({ timeout: 10_000 });
+
+  // Every reconnect attempt fails while armed, same technique as the socket-kill test above,
+  // so "genuinely offline" is a stable window rather than a race against wrangler dev's resume.
+  // Re-navigating to `/join/:code` (rather than closing the already-open `/sort` socket in
+  // place) is what the socket-kill test above does too: it forces a fresh connection attempt
+  // that the just-armed route is guaranteed to intercept, instead of racing the in-flight
+  // socket's own close/reconnect cycle.
+  await pageA.routeWebSocket(WS_PATTERN, (ws) => {
+    ws.close({ code: 1006, reason: 'e2e: simulated drop' });
+  });
+  await pageA.goto(`/join/${code}`);
+  await pageA.waitForFunction(() => Boolean(window.__VC_TEST__), { timeout: 10_000 });
+  await pageA.evaluate(() => window.__VC_TEST__?.closeSocket());
+  await expect(pageA.getByRole('status')).toHaveText('Reconnecting…', { timeout: 10_000 });
+
+  await pageA.evaluate((c) => {
+    const token = JSON.parse(localStorage.getItem(`vc:${c}:token`) ?? 'null') as { participantId: string };
+    window.__VC_TEST__?.send({
+      type: 'reportProgress',
+      intentId: crypto.randomUUID(),
+      participantId: token.participantId,
+      round: 1,
+      sorted: 3,
+      kept: 2,
+      done: false,
+    });
+  }, code);
+
+  await pageA.routeWebSocket(WS_PATTERN, (ws) => {
+    ws.connectToServer();
+  });
+  await expect(pageA.getByRole('status').filter({ hasText: 'Reconnecting' })).toHaveCount(0, { timeout: 20_000 });
+
+  await expect(adaRowOnB).toContainText('Round 1 · 3 sorted · 2 kept', { timeout: 20_000 });
+
+  await contextA.close();
+  await contextB.close();
+});

--- a/party/src/index.ts
+++ b/party/src/index.ts
@@ -9,6 +9,8 @@ export { SessionServer };
 
 const SESSION_PATH = '/api/session';
 const WS_PATH_PATTERN = /^\/api\/session\/([A-Z0-9]{6})\/ws$/;
+// Test/dev-only (spec 02.1's privacy E2E) — see session.ts's `/internal/dump`.
+const DUMP_PATH_PATTERN = /^\/api\/session\/([A-Z0-9]{6})\/dump$/;
 const MAX_CODE_ATTEMPTS = 5;
 
 async function createSession(env: Env, config: GameConfig): Promise<{ code: string; creatorToken: string }> {
@@ -50,6 +52,13 @@ export default {
       const code = wsMatch[1] as string;
       const stub = env.Session.get(env.Session.idFromName(code));
       return stub.fetch(request);
+    }
+
+    const dumpMatch = url.pathname.match(DUMP_PATH_PATTERN);
+    if (dumpMatch) {
+      const code = dumpMatch[1] as string;
+      const stub = env.Session.get(env.Session.idFromName(code));
+      return stub.fetch('http://session/internal/dump');
     }
 
     return new Response('Not found', { status: 404 });

--- a/party/src/index.ts
+++ b/party/src/index.ts
@@ -54,7 +54,11 @@ export default {
       return stub.fetch(request);
     }
 
-    const dumpMatch = url.pathname.match(DUMP_PATH_PATTERN);
+    // Gated on an explicit opt-in binding that only `wrangler dev` and the e2e harness set.
+    // Unset in production, so this route does not exist there: an unauthenticated dump of a
+    // session reachable with nothing but a 6-char code would expose every participant's UUID,
+    // display name, role and progress — and reveal snapshots once 02.2 lands.
+    const dumpMatch = env.DEV_STATE_DUMP === 'true' ? url.pathname.match(DUMP_PATH_PATTERN) : null;
     if (dumpMatch) {
       const code = dumpMatch[1] as string;
       const stub = env.Session.get(env.Session.idFromName(code));

--- a/party/src/session.test.ts
+++ b/party/src/session.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { env, evictDurableObject, runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test';
+import { SELF, env, evictDurableObject, runDurableObjectAlarm, runInDurableObject } from 'cloudflare:test';
 import type { SessionState } from '@values-cards/shared';
 import { connect, createSession, join } from './test-helpers';
 import type { Env } from './session';
@@ -224,5 +224,22 @@ describe('expiry', () => {
     expect(error).toMatchObject({ type: 'error', code: 'not_found' });
 
     expect(await storedState(code)).toBeUndefined();
+  });
+});
+
+describe('dev state dump route', () => {
+  // The e2e privacy suite needs this route to inspect real persisted storage, but it must
+  // not exist in production: with no auth beyond a 6-char code it would expose every
+  // participant's UUID, display name, role and progress (and reveal snapshots from 02.2).
+  // `party/vitest.config.ts` deliberately does NOT set DEV_STATE_DUMP, so this asserts the
+  // production posture — only the e2e harness opts in, via playwright.config.ts.
+  it('404s when DEV_STATE_DUMP is unset', async () => {
+    const { code } = await createSession();
+    const socket = await connect(code);
+    await join(socket, 'Facilitator');
+
+    const response = await SELF.fetch(`http://test/api/session/${code}/dump`);
+    expect(response.status).toBe(404);
+    expect(await response.text()).not.toContain('Facilitator');
   });
 });

--- a/party/src/session.ts
+++ b/party/src/session.ts
@@ -50,6 +50,12 @@ export class SessionServer extends Server<Env> {
       await this.ctx.storage.setAlarm(Date.now() + SESSION_TTL_MS);
       return new Response(null, { status: 201 });
     }
+    // Test/dev-only storage dump (spec 02.1's privacy E2E): proves invariant 1 against the
+    // DO's *actual persisted storage*, not just the events it happened to broadcast. Read-only,
+    // no auth — same trust boundary as `/internal/init`, only ever reachable from the Worker.
+    if (request.method === 'GET' && url.pathname === '/internal/dump') {
+      return Response.json(this.session);
+    }
     return new Response('not found', { status: 404 });
   }
 

--- a/party/src/session.ts
+++ b/party/src/session.ts
@@ -8,6 +8,10 @@ const SESSION_TTL_MS = 24 * 60 * 60 * 1000;
 export interface Env {
   Session: DurableObjectNamespace<SessionServer>;
   SESSION_TOKEN_SECRET: string;
+  /** `'true'` only under `wrangler dev` / the e2e harness — exposes the read-only state
+   *  dump route used to prove invariant 1 against real persisted storage. Never set in
+   *  production; see the guard in `index.ts`. */
+  DEV_STATE_DUMP?: string;
 }
 
 interface ConnState {

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -15,7 +15,7 @@ export default defineConfig({
       // The session DO (spec 01.1) — Vite proxies /api to it (app/vite.config.ts).
       // Deterministic test-only secret, matching party/vitest.config.ts's convention.
       command:
-        'pnpm --filter @values-cards/party exec wrangler dev --port 8799 --var SESSION_TOKEN_SECRET:test-e2e-secret-do-not-use-in-prod',
+        'pnpm --filter @values-cards/party exec wrangler dev --port 8799 --var SESSION_TOKEN_SECRET:test-e2e-secret-do-not-use-in-prod --var DEV_STATE_DUMP:true',
       url: 'http://127.0.0.1:8799/api/health',
       reuseExistingServer: !process.env['CI'],
       timeout: 60_000,

--- a/shared/src/engine/apply-intent.test.ts
+++ b/shared/src/engine/apply-intent.test.ts
@@ -175,6 +175,13 @@ describe('applyIntent: startGame', () => {
     const result = applyIntent(state, { type: 'startGame', intentId: 'i1', participantId: PARTICIPANT });
     expect('rejection' in result).toBe(true);
   });
+
+  it('allows any participant to start a non-facilitated game (02.1)', () => {
+    const state = baseState({ config: { ...baseState().config, facilitated: false } });
+    const result = applyIntent(state, { type: 'startGame', intentId: 'i1', participantId: PARTICIPANT });
+    if ('rejection' in result) throw new Error('unexpected rejection');
+    expect(result.state.phase).toBe('active');
+  });
 });
 
 describe('applyIntent: reportProgress', () => {

--- a/shared/src/engine/apply-intent.ts
+++ b/shared/src/engine/apply-intent.ts
@@ -125,7 +125,11 @@ export function applyIntent(state: SessionState, intent: Intent, deps: ApplyInte
     case 'startGame': {
       const participant = requireParticipant(state, intent.participantId);
       if (!participant) return reject('UNKNOWN_PARTICIPANT', 'no participant with that id');
-      if (participant.role !== 'facilitator') return reject('FORBIDDEN', 'only the facilitator can start the game');
+      // A facilitated game only the facilitator can kick off; a non-facilitated (peer) game
+      // is a group activity with no single owner, so any participant may start it (02.1).
+      if (state.config.facilitated && participant.role !== 'facilitator') {
+        return reject('FORBIDDEN', 'only the facilitator can start the game');
+      }
       if (state.phase !== 'lobby') return reject('LOCKED', 'game already started');
       const next = recordProcessed({ ...state, phase: 'active' as const }, intent.participantId, intent.intentId);
       return ok(next, [{ type: 'patch', patch: { phase: next.phase } }]);

--- a/specs/02-multiplayer/02.1-presence-progress.md
+++ b/specs/02-multiplayer/02.1-presence-progress.md
@@ -43,25 +43,25 @@ without ever sharing card contents.
 - Spotlight → **02.3**.
 
 ## Acceptance criteria
-- [ ] `reportProgress` debounce: a burst of 10 rapid keeps produces one intent with final
+- [x] `reportProgress` debounce: a burst of 10 rapid keeps produces one intent with final
       counts (unit test with fake timers, `app/src/session/milestones.test.ts`).
-- [ ] **Invariant 1 (PRD §6.1, end-to-end):** two-browser E2E `e2e/presence.spec.ts`
+- [x] **Invariant 1 (PRD §6.1, end-to-end):** two-browser E2E `e2e/presence.spec.ts`
       captures every WebSocket frame from both clients through join + full round pre-
       reveal and asserts no frame or roster render contains any card value/description;
       DO storage dump (dev endpoint or test hook) contains none either.
-- [ ] Two-browser E2E: B sees A appear in the roster on join, sees A's counts advance
+- [x] Two-browser E2E: B sees A appear in the roster on join, sees A's counts advance
       while A sorts, and sees A marked "Done ✓" at result screen.
-- [ ] Connection dot: killing A's socket flips A to disconnected on B's roster within
+- [x] Connection dot: killing A's socket flips A to disconnected on B's roster within
       5s; rejoin flips it back (`e2e/presence-connection.spec.ts`).
-- [ ] Avatar hue is identical for the same UUID across both browsers (E2E asserts
+- [x] Avatar hue is identical for the same UUID across both browsers (E2E asserts
       matching computed style / data-hue attribute).
-- [ ] Gated round notice blocks Continue until a `setGate` patch opens the round
+- [x] Gated round notice blocks Continue until a `setGate` patch opens the round
       (component test driving the store with a patch; control UI not required).
-- [ ] Offline-sorted progress arrives after reconnect (extends `e2e/reconnect.spec.ts`:
+- [x] Offline-sorted progress arrives after reconnect (extends `e2e/reconnect.spec.ts`:
       counts on B eventually match A's offline sorting).
-- [ ] Roster is accessible: list semantics, names + status readable by screen reader
+- [x] Roster is accessible: list semantics, names + status readable by screen reader
       (Testing Library role assertions).
-- [ ] `pnpm gate` green.
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -70,7 +70,7 @@
         "01.2",
         "01.4"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "02.2",


### PR DESCRIPTION
Implements [specs/02-multiplayer/02.1-presence-progress.md](specs/02-multiplayer/02.1-presence-progress.md).

## What landed
- `app/src/components/Roster.tsx` — live roster with connection dots and avatar hues; collapsible strip during sort.
- `app/src/components/GatedContinue.tsx` + `app/src/session/milestones.ts` — progress reporting and gated round advancement.
- A pre-start **lobby** in `routes/Sort` (per this spec's scope) with roster, config summary and Start game.
- `e2e/presence.spec.ts`, `e2e/presence-connection.spec.ts` — two-browser presence, progress, and privacy coverage.

## Test evidence
`pnpm gate` green, verified independently after rebasing onto current `v2`:

```
Test Files  36 passed (36)
     Tests  243 passed (243)
  48 passed (39.7s)   [desktop-chromium + mobile-chromium]
```

## ⚠️ Fixed in review: the dev state-dump route was publicly reachable

The loop added `GET /api/session/:code/dump`, returning the DO's full persisted state. Its own comment claimed *"no auth — same trust boundary as `/internal/init`, only ever reachable from the Worker"* — but the Worker **routed it publicly**, unauthenticated and with no environment gate. Anyone with a 6-char session code could read every participant's UUID, display name, role and progress, plus reveal snapshots once 02.2 lands.

The spec does sanction this ("DO storage dump (dev endpoint or test hook)"), but a dev endpoint has to actually be dev-gated. It's now gated on a `DEV_STATE_DUMP` binding that only `wrangler dev` sets via `playwright.config.ts`, so **the route does not exist in production**. Added a party test asserting it 404s when the binding is unset — `party/vitest.config.ts` deliberately doesn't set it, so that test encodes the production posture rather than just documenting it.

## Resolved: 02.1 and 03.1 disagreed about where the lobby lives

Rebasing onto 03.1 surfaced a real spec conflict, not just a merge conflict:
- **03.1** put a lobby on `Join`/`Create`, with the acceptance criterion that a joiner "sees the classic config in its lobby."
- **02.1** scopes the lobby to `routes/Sort`'s pre-start state ("Before `startGame`, joined participants see the roster + waiting-to-start state").

Resolved in favour of 02.1, which owns the pre-start participant experience — so there is **one** lobby, not two. A joined participant hands off to `/sort` and waits there; 03.1's `routes/lobby` remains the *creator's* lobby on `/create`.

To keep 03.1's criterion true, the `/sort` lobby now renders the round list, so a participant sees the config and sees facilitator `updateConfig` edits arrive live. `e2e/create.spec.ts` passes **unmodified** against it — I didn't relax that test to fit.

## Merged-contract change (spec-mandated)
`shared/src/engine/apply-intent.ts`'s `startGame` rejection changed from `role !== 'facilitator'` to `config.facilitated && role !== 'facilitator'`. **Any participant can now start a non-facilitated game.** Required by this spec's Lobby scope ("any participant may start a non-facilitated game, only the facilitator starts a facilitated one"). Facilitated games are unaffected — the existing rejection test's fixture is `facilitated: true` and passes unmodified; a new test covers the `facilitated: false` path.

## Invariant 1 — how it's actually proven
`e2e/presence.spec.ts` registers `page.on('websocket')` `framesent`/`framereceived` handlers on **both** browser contexts, capturing every raw frame from join through lobby, start, and a full round to result. `assertNoCardLeak` then parses each frame, recursively strips the `config` key (the deck listing is public config every client legitimately receives), and asserts no deck card value or description appears in what remains. The same assertion runs against the DO's real persisted storage via the dump route. Schema-level, `Participant.progress` is typed `{round, sorted, kept: number, done}` — structurally incapable of carrying a card id.

## Real bug the loop found in merged 01.2 code
`JoiningSession` redirected to `/sort` as soon as resync completed, but `ws.send()` only hands a frame to the network stack — it doesn't block until transmission. The redirect could tear the page down before a just-flushed offline-queued intent left the socket, silently dropping it. Fixed by gating the redirect on `connection === 'live'` and deferring navigation 100ms. The loop reproduced this deterministically without the fix. I left a TODO noting the delay becomes unnecessary once a client-side router replaces the full-document navigation.

## Other deviations
- `app/src/session/tokens.ts` gained `saveCurrentCode`/`loadCurrentCode` so `/sort` knows which session to resume without putting the code in the URL (existing e2e assert `/\/sort$/`).

No existing tests were loosened or deleted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)