### PR TITLE
fix: make local dev actually runnable and fail legibly without a secret

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,29 @@ with a beautiful export. Facilitators design the game itself — rounds, deck, a
 
 **Status: v2 rebuild in progress.**
 
+## Running it locally
+
+```bash
+nvm use                              # Node >= 22
+pnpm install
+cp party/.dev.vars.example party/.dev.vars   # one-time: the DO needs a token-signing secret
+```
+
+Then two terminals:
+
+```bash
+cd app && pnpm dev      # http://localhost:5173
+cd party && pnpm dev    # the session Durable Object on :8799
+```
+
+Vite proxies `/api` to the Durable Object, so use the app origin (`:5173`) in the browser —
+not the wrangler port. The dev port is set once in `party/wrangler.jsonc`; if you change it,
+change `app/vite.config.ts`'s proxy target and `playwright.config.ts` to match.
+
+`party/.dev.vars` is gitignored and local-only. Without it, `POST /api/session` fails —
+`SESSION_TOKEN_SECRET` signs the HMAC participant/creator tokens, so there is deliberately
+no default.
+
 - Plan of record: [design](docs/plans/2026-08-02-values-cards-2.0-design.md) ·
   [PRD](docs/plans/2026-08-02-values-cards-2.0-prd.md) ·
   [architecture](docs/plans/2026-08-02-values-cards-2.0-architecture.md)

--- a/party/src/token.test.ts
+++ b/party/src/token.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+import { mintCreatorToken, mintParticipantToken, verifyCreatorToken, verifyParticipantToken } from './token';
+
+const SECRET = 'test-secret-do-not-use-in-prod';
+const CODE = 'ABC123';
+
+describe('token secret guard', () => {
+  // An unset SESSION_TOKEN_SECRET otherwise reaches WebCrypto as a zero-length key and
+  // surfaces as "Imported HMAC key length (0)...", which says nothing about the cause.
+  // This bit real manual dev: `POST /api/session` 500s with a crypto stack trace.
+  it('throws an actionable error when the secret is empty rather than a crypto error', async () => {
+    await expect(mintCreatorToken('', CODE)).rejects.toThrow(/SESSION_TOKEN_SECRET is not set/);
+    await expect(mintParticipantToken('', CODE, 'p1')).rejects.toThrow(/\.dev\.vars/);
+  });
+});
+
+describe('token round-trip', () => {
+  it('mints and verifies a creator token, and rejects one for a different code', async () => {
+    const token = await mintCreatorToken(SECRET, CODE);
+    expect(await verifyCreatorToken(SECRET, CODE, token)).toBe(true);
+    expect(await verifyCreatorToken(SECRET, 'ZZZ999', token)).toBe(false);
+    expect(await verifyCreatorToken('other-secret', CODE, token)).toBe(false);
+  });
+
+  it('mints and verifies a participant token, returning the id only on a valid signature', async () => {
+    const token = await mintParticipantToken(SECRET, CODE, 'participant-1');
+    expect(await verifyParticipantToken(SECRET, CODE, token)).toBe('participant-1');
+    expect(await verifyParticipantToken(SECRET, CODE, `${token}tampered`)).toBeNull();
+    expect(await verifyParticipantToken(SECRET, CODE, 'no-dot-separator')).toBeNull();
+  });
+});

--- a/party/src/token.ts
+++ b/party/src/token.ts
@@ -8,6 +8,14 @@
 const encoder = new TextEncoder();
 
 async function hmacKey(secret: string): Promise<CryptoKey> {
+  // Without this, an unset binding reaches WebCrypto as a zero-length key and surfaces as
+  // "Imported HMAC key length (0)..." — a crypto error that says nothing about the actual
+  // cause. There is deliberately no default: this secret signs every participant token.
+  if (!secret) {
+    throw new Error(
+      'SESSION_TOKEN_SECRET is not set. For local dev: cp party/.dev.vars.example party/.dev.vars (see README).',
+    );
+  }
   return crypto.subtle.importKey('raw', encoder.encode(secret), { name: 'HMAC', hash: 'SHA-256' }, false, [
     'sign',
     'verify',

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -17,7 +17,10 @@ export default defineConfig({
       command:
         'pnpm --filter @values-cards/party exec wrangler dev --port 8799 --var SESSION_TOKEN_SECRET:test-e2e-secret-do-not-use-in-prod --var DEV_STATE_DUMP:true',
       url: 'http://127.0.0.1:8799/api/health',
-      reuseExistingServer: !process.env['CI'],
+      // Never reuse a manually-started `pnpm dev` here: it won't have the test-only
+      // `DEV_STATE_DUMP` binding, so the privacy suite's storage-dump assertion 404s and
+      // reports as a code failure. Failing with "address in use" is far more legible.
+      reuseExistingServer: false,
       timeout: 60_000,
     },
     {


### PR DESCRIPTION
Found by manual verification, not by tests — and that's the point.

## The bug

`POST /api/session` 500s on a fresh checkout:

```
DataError: Imported HMAC key length (0) must be a non-zero value...
    at hmacKey (party/src/token.ts:11:24)
```

`party/.dev.vars` doesn't exist by default (it's gitignored), so `SESSION_TOKEN_SECRET` is unset, and an empty key reaches WebCrypto. The error names nothing relevant to the actual cause.

**Why the suite never caught it:** `playwright.config.ts` injects `SESSION_TOKEN_SECRET` via `--var`. So the full stack was only ever exercised through a harness that supplied the missing piece. `party/.dev.vars.example` existed since 01.1, but nothing documented copying it and nothing failed helpfully when you didn't.

## Fixes

- **README**: the one-time `cp party/.dev.vars.example party/.dev.vars` step, both dev commands, and a note that the browser should use the app origin (`:5173`), not the wrangler port.
- **`token.ts`**: throw an actionable error naming the missing binding and the fix, instead of letting an empty key reach WebCrypto. No default value — this secret signs every participant and creator token, so falling back to one would be worse than failing.
- **`token.test.ts`** (new): the guard, plus creator/participant round-trips, wrong-code and wrong-secret rejection, and tampered/malformed tokens. `token.ts` had no direct unit coverage before this.
- **`playwright.config.ts`**: stop reusing a manually-started wrangler for e2e.

## The reuse footgun (worth its own mention)

`reuseExistingServer: !CI` meant Playwright would adopt a hand-started `pnpm dev` — which lacks the test-only `DEV_STATE_DUMP` binding. The privacy suite's storage-dump assertion then 404s and reports as a **code failure**. This bit me mid-verification and cost a confusing debug cycle; it would bite anyone running the suite with a dev server up. Now it refuses to reuse, and "address in use" says what's actually wrong.

This is the same class of problem as the port contention I flagged earlier: shared local state making test results lie.

## Verified by hand, not just by tests

With `.dev.vars` present, bare `pnpm dev` (no flags):

```
POST /api/session          → {"code":"6U2N8R","creatorToken":"Ld5vYA..."}
GET  /api/session/X/dump   → 404      # correctly closed outside the e2e harness
```

That second line also confirms the production posture of the dump route gate from #46 holds in a real dev server, not only in the unit test.

```
Test Files  37 passed (37)
     Tests  246 passed (246)
  48 passed (38.7s)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)