### PR TITLE
fix: keep the bottom sheet dismissable when its content overflows

### DIFF
--- a/app/src/components/Sheet.tsx
+++ b/app/src/components/Sheet.tsx
@@ -1,21 +1,39 @@
-import type { ReactNode } from 'react';
+import { useEffect, type ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
 export interface SheetProps {
   open: boolean;
+  /** Closes on Escape when provided. Without it the sheet has no keyboard dismissal. */
+  onClose?: () => void;
   children?: ReactNode;
 }
 
 /**
- * Minimal bottom sheet, anchored above modals. Full gesture/drag-to-dismiss
- * behavior is out of scope here — 01.3/02.1 compose interaction on top.
+ * Minimal bottom sheet, anchored above modals.
+ *
+ * Height is bounded: an unbounded `bottom-0` sheet grows upward as content grows, and once
+ * it exceeds the viewport its top — where dismiss controls live — is pushed off-screen with
+ * nothing to scroll, stranding the user (this happened with a full kept tray). Content that
+ * can grow must live in its own `overflow-y-auto` child so dismiss controls stay put.
  */
-export function Sheet({ open, children }: SheetProps) {
+export function Sheet({ open, onClose, children }: SheetProps) {
+  useEffect(() => {
+    if (!open || !onClose) return;
+    const close = onClose;
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key !== 'Escape') return;
+      event.preventDefault();
+      close();
+    }
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [open, onClose]);
+
   if (!open) return null;
   return createPortal(
     <div
       role="region"
-      className="fixed inset-x-0 bottom-0 z-sheet rounded-t-sheet bg-surface-raised p-6 shadow-sheet"
+      className="fixed inset-x-0 bottom-0 z-sheet flex max-h-[85dvh] flex-col rounded-t-sheet bg-surface-raised p-6 shadow-sheet"
     >
       {children}
     </div>,

--- a/app/src/engine-ui/KeptTray.test.tsx
+++ b/app/src/engine-ui/KeptTray.test.tsx
@@ -45,4 +45,45 @@ describe('KeptTray', () => {
     await userEvent.click(demoteButtons[0] as HTMLElement);
     expect(onDemote).toHaveBeenCalledWith('Courage');
   });
+
+  // Regression: with a full tray the sheet grew past the viewport and its header — the only
+  // dismiss control — was pushed off-screen with nothing to scroll, stranding the user in
+  // the tray with no way back to the sort UI.
+  describe('a full tray stays dismissable', () => {
+    const FULL = Array.from({ length: 8 }, (_, i) => ({
+      value: `Value ${i + 1}`,
+      description: `Description ${i + 1}`,
+    }));
+
+    it('keeps Close outside the scrolling card grid', async () => {
+      renderTray(<KeptTray cards={FULL} limit={8} onDemote={vi.fn()} />);
+      await userEvent.click(screen.getByRole('button', { name: 'Kept cards: 8 / 8 kept' }));
+
+      const close = screen.getByRole('button', { name: 'Close' });
+      const grid = screen.getByText('Value 1').closest('.overflow-y-auto');
+      expect(grid).not.toBeNull();
+      // Close must not live inside the scroll container, or it scrolls away with the cards.
+      expect(grid?.contains(close)).toBe(false);
+      // ...and the sheet itself must be height-bounded, or there is nothing to scroll.
+      expect(close.closest('[role="region"]')?.className).toContain('max-h-');
+    });
+
+    it('closes a full tray with Close, returning to the sort UI', async () => {
+      renderTray(<KeptTray cards={FULL} limit={8} onDemote={vi.fn()} />);
+      await userEvent.click(screen.getByRole('button', { name: 'Kept cards: 8 / 8 kept' }));
+      expect(screen.getByText('Value 1')).toBeDefined();
+
+      await userEvent.click(screen.getByRole('button', { name: 'Close' }));
+      expect(screen.queryByText('Value 1')).toBeNull();
+    });
+
+    it('closes on Escape, so dismissal never depends on layout', async () => {
+      renderTray(<KeptTray cards={FULL} limit={8} onDemote={vi.fn()} />);
+      await userEvent.click(screen.getByRole('button', { name: 'Kept cards: 8 / 8 kept' }));
+      expect(screen.getByText('Value 1')).toBeDefined();
+
+      await userEvent.keyboard('{Escape}');
+      expect(screen.queryByText('Value 1')).toBeNull();
+    });
+  });
 });

--- a/app/src/engine-ui/KeptTray.tsx
+++ b/app/src/engine-ui/KeptTray.tsx
@@ -27,14 +27,16 @@ export function KeptTray({ cards, limit, onDemote }: KeptTrayProps) {
       >
         {countLabel}
       </Button>
-      <Sheet open={open}>
-        <div className="flex items-center justify-between gap-4">
+      <Sheet open={open} onClose={() => setOpen(false)}>
+        {/* `shrink-0` keeps Close pinned while the grid below scrolls — with a full tray the
+            grid is taller than the sheet, and Close must never scroll out of reach. */}
+        <div className="flex shrink-0 items-center justify-between gap-4">
           <h2 className="font-display text-lg font-semibold text-ink">Kept</h2>
           <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
             Close
           </Button>
         </div>
-        <div className="mt-4 grid grid-cols-2 gap-4 sm:grid-cols-3">
+        <div className="mt-4 grid grid-cols-2 gap-4 overflow-y-auto sm:grid-cols-3">
           {cards.map((card) => (
             <div key={card.value} className="flex flex-col items-center gap-2">
               <GameCard title={card.value} description={card.description} size="sm" />

--- a/app/src/routes/KitchenSink.tsx
+++ b/app/src/routes/KitchenSink.tsx
@@ -80,7 +80,7 @@ export function KitchenSink() {
           <p className="mb-4 text-ink-muted">Modal content lives here.</p>
           <Button onClick={() => setModalOpen(false)}>Close</Button>
         </Modal>
-        <Sheet open={sheetOpen}>
+        <Sheet open={sheetOpen} onClose={() => setSheetOpen(false)}>
           <p className="text-ink-muted">Sheet content lives here.</p>
         </Sheet>
       </section>


### PR DESCRIPTION
User-reported: **with a full kept tray there was no way back to the sort UI.**

## Cause

`Sheet` was `fixed inset-x-0 bottom-0` with no bounded height and no scroll container:

```tsx
<div role="region" className="fixed inset-x-0 bottom-0 z-sheet ... p-6">
```

Anchored to the bottom, growing content pushes the *top* edge upward. Past roughly 6–8 kept cards (each card plus its Demote button, two columns on mobile) the header row holding "Close" went above the viewport top — with nothing to scroll, because a `fixed` element with no `max-height` has no overflow. The only dismiss control became physically unreachable.

Compounding it: `Sheet` had no Escape handler, so there was no keyboard way out either. `Modal` has a full focus trap with Escape; `Sheet` had neither.

## Fix — at the primitive, not just the caller

Any sheet whose content can grow past the viewport has this trap, so the bound belongs in `Sheet`:

- **`Sheet`**: bounded height (`max-h-[85dvh]`) as a flex column, and closes on Escape when `onClose` is supplied — so dismissal no longer depends on layout at all.
- **`KeptTray`**: `shrink-0` header keeps Close pinned; the card grid scrolls in its own `overflow-y-auto` child.
- **`KitchenSink`**: passes `onClose` so the showcased sheet demonstrates Escape too.

Deliberately did **not** add a focus trap to `Sheet` — it's a non-modal `role="region"` that doesn't block the page, and trapping focus in a non-modal surface would be the wrong behavior. Escape is the affordance that was missing.

## Regression tests, verified to actually fail before the fix

I stashed the `Sheet` change and re-ran to confirm the tests catch the bug rather than just describing it:

```
× keeps Close outside the scrolling card grid
× closes on Escape, so dismissal never depends on layout
Tests  2 failed | 5 passed (7)
```

**Honest limitation:** the third new test — clicking Close with a full tray — passes either way, because jsdom has no layout and can't reproduce the off-screen condition. The height-bound assertion is the structural proxy for it. A true visual regression test would need a real browser at a fixed viewport with a full tray; worth adding in 04.2 (Hardening) if this class of bug recurs.

## Test evidence

```
Test Files  37 passed (37)
     Tests  249 passed (249)
  48 passed (39.2s)
```

**Flake noted:** on one run `e2e/presence-connection.spec.ts` failed waiting for `data-connected="true"` after rejoin. It then passed 6/6 with `--repeat-each=3` and clean on a full re-run, and is untouched by this change — so it's a flake in that presence test, not a regression here. Flagging it rather than burying it; if it recurs it needs a proper fix rather than a retry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)