### PR TITLE
fix: facilitator lands in the real session on /sort, not the local demo

### DIFF
--- a/app/src/routes/Create.tsx
+++ b/app/src/routes/Create.tsx
@@ -4,7 +4,7 @@ import { CLASSIC_TEMPLATE } from '@values-cards/decks/templates.js';
 import { Button } from '../components/Button';
 import { ConnectionPill } from '../session/ConnectionPill';
 import { intents } from '../session/intents';
-import { loadToken } from '../session/tokens';
+import { loadToken, saveCurrentCode } from '../session/tokens';
 import { useSession } from '../session/useSession';
 import { Designer } from './create/designer';
 import { Lobby } from './lobby';
@@ -98,6 +98,14 @@ export function Create() {
         </p>
       ) : null}
 
+      {/* Surface WHY the button is disabled — a silently-dead "Create game" with no
+          explanation read as a broken button (the empty-name case in particular). */}
+      {!result.ok ? (
+        <p className="text-sm text-danger">{result.errors[0]?.message ?? 'Fix the game settings to continue.'}</p>
+      ) : name.trim().length === 0 ? (
+        <p className="text-sm text-ink-muted">Enter your name to create the game.</p>
+      ) : null}
+
       <Button type="button" onClick={createGame} disabled={!canCreate}>
         {creating ? 'Creating…' : 'Create game'}
       </Button>
@@ -121,13 +129,17 @@ function CreateLobby({ code, creatorToken, name }: { code: string; creatorToken:
 
   useEffect(() => {
     const token = loadToken(code);
-    if (!token || !state) return;
+    // Mirror Join.tsx's hand-off exactly: `/sort` decides real-session vs. local demo by
+    // `loadCurrentCode()`, so the creator MUST record the code here too — without it the
+    // facilitator dropped into the standalone demo sort, disconnected from its own session.
+    // Gate on `connection === 'live'` and defer so the just-sent `startGame` flushes before
+    // the full-document navigation tears the socket down.
+    if (!token || !state || connection !== 'live') return;
     if (state.phase === 'active') {
-      // 01.3/01.4 own the real sort route; this is the placeholder hand-off (out of
-      // scope here), same as Join.tsx's.
-      window.location.assign('/sort');
+      saveCurrentCode(code);
+      setTimeout(() => window.location.assign('/sort'), 100);
     }
-  }, [state, code]);
+  }, [state, code, connection]);
 
   const token = loadToken(code);
   if (!state || !token || !state.participants[token.participantId]) {

--- a/e2e/create.spec.ts
+++ b/e2e/create.spec.ts
@@ -74,3 +74,45 @@ test('lobby updateConfig broadcasts to joined participants; startGame locks the 
 
   await second.close();
 });
+
+// Regression: the facilitator who reached /sort via the Create page dropped into the
+// standalone local demo instead of the real session, because CreateLobby's redirect never
+// recorded the session code (Join.tsx did; Create.tsx didn't). Presence tests created
+// sessions via the API and joined everyone, so they never exercised the creator's redirect.
+// This drives the real Create-page path and asserts both players are in ONE live session.
+test('facilitator created via the Create page joins the real session on /sort, not the demo', async ({ page, browser }) => {
+  await page.goto('/create');
+  await page.getByLabel('Your name').fill('Coach');
+  await page.getByRole('button', { name: 'Create game' }).click();
+
+  const shareLink = page.getByLabel('Share link');
+  await expect(shareLink).toHaveValue(/\/join\/[A-Z0-9]{6}$/, { timeout: 10_000 });
+  const code = (await shareLink.inputValue()).split('/').pop() as string;
+
+  const second = await browser.newContext();
+  const bPage = await second.newPage();
+  await bPage.goto(`/join/${code}`);
+  await bPage.getByLabel('Display name').fill('Ada');
+  await bPage.getByRole('button', { name: 'Join' }).click();
+  await expect(bPage.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+
+  // Facilitator starts; both clients land on /sort in the SAME session.
+  await page.getByRole('button', { name: 'Start game' }).click();
+  await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
+  await expect(bPage).toHaveURL(/\/sort$/, { timeout: 10_000 });
+
+  // The demo route has no shared roster and could never show the other participant. The
+  // facilitator seeing "Ada" proves they're in the real multiplayer session.
+  await page.getByRole('button', { name: /Show participants/ }).click();
+  await expect(page.getByRole('listitem').filter({ hasText: 'Ada' })).toBeVisible({ timeout: 10_000 });
+
+  // And progress flows facilitator -> joiner: Coach sorts one card, Ada's roster reflects it.
+  await bPage.getByRole('button', { name: /Show participants/ }).click();
+  await page.locator('body').click();
+  await page.keyboard.press('ArrowRight');
+  await expect(bPage.getByRole('listitem').filter({ hasText: 'Coach' })).toContainText('1 sorted', {
+    timeout: 10_000,
+  });
+
+  await second.close();
+});


### PR DESCRIPTION
Two user-reported bugs, one root cause plus a UX gap.

## Reported
1. Creating a game "didn't work" — the button took no action (turned out to be a missing player name, with **no error surfaced**).
2. With two players in a game, **neither saw the other's status**, and the console warned the websocket was closing.

## Root cause (bug 2) — found by driving two real browsers

I first ruled out the obvious suspects with a raw-ws probe against the running server: the DO's join broadcast, reconnect→snapshot, progress broadcast, hibernation, the store's patch-merge, and even Vite's dev WS proxy are **all correct**. The bug only reproduced in an actual browser.

`/sort` decides between the **real session** and a **standalone local demo** purely by `loadCurrentCode()`. `Join.tsx` records the code before redirecting; `Create.tsx`'s `CreateLobby` **did not** — so the *facilitator* dropped into the demo sort, disconnected from its own session. The facilitator's progress went to a local store and never reached the server, and it never received anyone else's patches. The joiner worked fine, which is exactly why it looked like one-way sync.

Browser diagnostics, before vs. after:
```
before →  A(creator): storeState=null, no vc:currentCode, showing the dev-12 demo deck
after  →  A(creator): storeState={participants:[David,Bob], phase:active}; B sees David's sorted count climb as he sorts
```

The "websocket is closed before the connection is established" warning was a red herring — benign React-StrictMode dev churn, correctly handled by the reconnect epoch logic.

## Why no test caught it
The presence e2e (`presence.spec.ts`, `reconnect.spec.ts`) create sessions via `request.post('/api/session')` and join every participant — they never exercised the Create-*page* facilitator redirect. The one path with the bug was the one path no test drove.

## Fixes
- **`Create.tsx`**: `saveCurrentCode(code)` before the `/sort` hand-off, mirroring `Join.tsx` exactly — including its `connection === 'live'` guard and deferred navigation so the just-sent `startGame` flushes before the socket tears down.
- **`Create.tsx` (bug 1)**: surface *why* "Create game" is disabled — a missing name (or invalid config) now shows a message instead of a silently dead button.
- **`e2e/create.spec.ts`**: regression test driving the real Create-page facilitator path through to `/sort`, asserting both players share one live session and progress flows facilitator→joiner. **Verified it fails without the fix** (facilitator never sees the joiner) and passes with it.

## Test evidence
Full gate green (typecheck, lint, token-lint, 249 unit, 50 e2e) at `--workers=2`.

Note: at default parallelism on a loaded machine the timing-sensitive reconnect tests (`presence-connection`, `reconnect`) flake locally, since local runs use `retries: 0` while CI uses 2. Pre-existing, unrelated to this change, and worth a separate robustness pass (local retries or wider windows) — flagging rather than burying.

## Also found (not fixed here)
`app/src/vite.config.ts` doesn't pin the dev port, and Vite binds `localhost` (IPv6). With another Vite project running alongside, the app silently lands on a different port / interface — real confusion during debugging. Worth pinning in a follow-up; left out of this PR to keep it focused on the reported bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)