### PR TITLE
fix: pin the dev port and stabilize full-stack e2e under load

### DIFF
--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -8,6 +8,12 @@ import { defineConfig } from 'vite';
 export default defineConfig({
   plugins: [react(), tailwindcss()],
   server: {
+    // Pin the port and fail loudly if it's taken, rather than silently drifting to 5174+
+    // when another Vite project is already on 5173 — a silent drift means the browser tab
+    // and the app end up on different servers, which reads as "nothing works". README
+    // documents :5173. (Playwright overrides this via `--port 5199 --strictPort`.)
+    port: 5173,
+    strictPort: true,
     proxy: {
       '/api': { target: 'http://127.0.0.1:8799', changeOrigin: true, ws: true },
     },

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,7 +4,16 @@ export default defineConfig({
   testDir: './e2e',
   fullyParallel: true,
   forbidOnly: !!process.env['CI'],
-  retries: process.env['CI'] ? 2 : 0,
+  // Full-stack WS tests (reconnect/presence) have real timing variance under parallel load
+  // against the single Miniflare DO. They pass 5/5 in isolation; the residual flake is
+  // contention, not a logic bug. CI already retries; give local runs one retry too so a
+  // green suite doesn't depend on machine load. The workers cap below keeps it rare.
+  retries: process.env['CI'] ? 2 : 1,
+  // Every worker's browser hits the SAME single `wrangler dev` (Miniflare) session server,
+  // so full-stack parallelism is bounded by that one DO, not by CPU. Uncapped (one worker
+  // per core — 14 here) oversubscribes it and the timing-sensitive reconnect/presence tests
+  // exceed their windows. Cap local runs to keep the DO responsive; CI keeps its 2 retries.
+  workers: process.env['CI'] ? undefined : 4,
   reporter: process.env['CI'] ? [['list'], ['html', { open: 'never' }]] : 'list',
   use: {
     baseURL: 'http://localhost:5199',


### PR DESCRIPTION
Two dev-experience follow-ups from the [creator-drops-into-demo fix (#49)](https://github.com/dgrumm/leadership-values-card-sort/pull/49) investigation.

## 1. Pin the Vite dev port

Vite defaults to 5173 and **silently drifts to 5174+** when the port is taken. So with another Vite project already running, `pnpm dev` serves the app on an unexpected port while the browser tab sits on 5173 — a *different* app — which reads as "nothing works." This actually happened mid-debugging: a sibling project (`calendar-planner`) was holding 5173, and it cost real time to notice the app had drifted.

Set `port: 5173, strictPort: true` in `app/vite.config.ts` so a collision fails loudly:

```
Error: Port 5173 is already in use
```

Playwright still overrides via `--port 5199 --strictPort`, so e2e is unaffected.

**Verified:** `pnpm dev` binds 5173; a second `pnpm dev` errors immediately instead of drifting.

## 2. Stabilize timing-sensitive e2e under load

Every Playwright worker's browser hits the **same single `wrangler dev` (Miniflare) DO**, so full-stack parallelism is bounded by that one server, not CPU. Uncapped (one worker per core — 14 on this machine) oversubscribes it, and the reconnect/presence tests exceed their timing windows.

Evidence this is contention, not a bug:
- `presence-connection` passes **5/5 in isolation**.
- The product is independently verified correct (two-browser probe: progress syncs, reconnect resyncs) in #49.
- It only fails under full-suite parallel load, and intermittently.

Fixes:
- **`workers`**: cap local runs to 4 (CI unchanged) so the DO stays responsive.
- **`retries`**: 1 locally (was 0; CI stays 2) so a green suite doesn't hinge on machine load.

This is **not masking a product bug** — it matches CI's existing `retries: 2`, which already acknowledges these full-stack WS tests have real timing variance. The workers cap makes the retry rarely needed.

**Verified:** 3 consecutive green full e2e runs (50 passed) where uncapped default parallelism intermittently failed `presence-connection`.

## Not addressed
The `presence-connection`/`reconnect` tests toggle `routeWebSocket` to simulate drops, which is inherently racy. If they keep surfacing, the durable fix is reworking that interception (or widening windows), not more retries — but that's a test-rewrite, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)