### PR TITLE
feat(00.4): Liquid glass aesthetic & card sizing

### DIFF
--- a/app/src/components/Button.tsx
+++ b/app/src/components/Button.tsx
@@ -32,7 +32,7 @@ export function Button({
 }: ButtonProps) {
   return (
     <button
-      className={`inline-flex items-center justify-center rounded-control font-semibold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${HIT_TARGET} ${VARIANT_CLASSES[variant]} ${SIZE_CLASSES[size]} ${className}`}
+      className={`inline-flex items-center justify-center rounded-control font-semibold transition-colors focus-visible:outline-none focus-visible:shadow-focus ${HIT_TARGET} ${VARIANT_CLASSES[variant]} ${SIZE_CLASSES[size]} ${className}`}
       {...props}
     />
   );

--- a/app/src/components/GameCard.test.tsx
+++ b/app/src/components/GameCard.test.tsx
@@ -2,24 +2,21 @@ import { cleanup, render, screen } from '@testing-library/react';
 import type { ReactElement } from 'react';
 import { afterEach, describe, expect, it } from 'vitest';
 import { MotionProvider } from '../theme/motion';
-import { GameCard, type GameCardSize } from './GameCard';
+import { GameCard } from './GameCard';
 
 afterEach(cleanup);
-
-const SIZES: GameCardSize[] = ['sm', 'md', 'lg'];
 
 function renderCard(card: ReactElement) {
   return render(<MotionProvider>{card}</MotionProvider>);
 }
 
 describe('GameCard', () => {
-  for (const size of SIZES) {
-    it(`renders a 5:7 portrait aspect at size=${size}`, () => {
-      renderCard(<GameCard title="Courage" size={size} />);
-      const card = screen.getByText('Courage').closest('[data-flipped]');
-      expect(card?.className).toContain('aspect-[5/7]');
-    });
-  }
+  it('renders one canonical 5:7 portrait size, with no size prop', () => {
+    renderCard(<GameCard title="Courage" />);
+    const card = screen.getByText('Courage').closest('[data-flipped]');
+    expect(card?.className).toContain('aspect-[5/7]');
+    expect(card?.className).toContain('w-[min(78vw,16rem)]');
+  });
 
   it('shows the front face with title and description by default', () => {
     renderCard(<GameCard title="Courage" description="Acting despite fear" />);

--- a/app/src/components/GameCard.tsx
+++ b/app/src/components/GameCard.tsx
@@ -1,23 +1,17 @@
 import { motion } from 'framer-motion';
 import { fadeOnlyVariants, transition, useMotionSafe } from '../theme/motion';
 
-export type GameCardSize = 'sm' | 'md' | 'lg';
-
 export interface GameCardProps {
   /** Value name shown on the front face, set in the display serif. */
   title: string;
   /** Short description shown beneath the title on the front face. */
   description?: string;
-  size?: GameCardSize;
   /** Shows the card-back face instead of the front. */
   flipped?: boolean;
 }
 
-const SIZE_CLASSES: Record<GameCardSize, string> = {
-  sm: 'w-32',
-  md: 'w-48',
-  lg: 'w-64',
-};
+// Single canonical size everywhere (fits 390px mobile, caps at 256px on desktop).
+const CARD_SIZE = 'w-[min(78vw,16rem)] aspect-[5/7]';
 
 // Mirrors --spring-stiffness/--spring-damping in tokens.css (Framer Motion
 // transitions take numbers, not CSS var strings).
@@ -38,14 +32,14 @@ const FLIP_VARIANTS = {
  * 3D flip (`backface-visibility: hidden` on stacked front/back layers) if
  * 01.3 needs the illusion to hold up under close inspection.
  */
-export function GameCard({ title, description, size = 'md', flipped = false }: GameCardProps) {
+export function GameCard({ title, description, flipped = false }: GameCardProps) {
   const motionSafe = useMotionSafe();
   const variants = fadeOnlyVariants(FLIP_VARIANTS, motionSafe);
 
   return (
     <motion.div
       data-flipped={flipped}
-      className={`aspect-[5/7] ${SIZE_CLASSES[size]} rounded-card shadow-card`}
+      className={`${CARD_SIZE} rounded-card border border-glass-edge bg-glass shadow-glass backdrop-blur-[var(--glass-blur)]`}
       variants={variants}
       initial={flipped ? 'back' : 'front'}
       animate={flipped ? 'back' : 'front'}
@@ -54,7 +48,7 @@ export function GameCard({ title, description, size = 'md', flipped = false }: G
       {flipped ? (
         <div className="flex h-full w-full items-center justify-center rounded-card bg-accent" />
       ) : (
-        <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded-card bg-surface-raised p-4 text-center">
+        <div className="flex h-full w-full flex-col items-center justify-center gap-2 rounded-card bg-glass-strong p-4 text-center">
           <h3 className="font-display text-xl font-semibold text-ink">{title}</h3>
           {description ? <p className="text-sm text-ink-muted">{description}</p> : null}
         </div>

--- a/app/src/components/Modal.tsx
+++ b/app/src/components/Modal.tsx
@@ -70,7 +70,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
 
   return createPortal(
     <div
-      className="fixed inset-0 z-modal flex items-center justify-center bg-ink/40"
+      className="fixed inset-0 z-modal flex items-center justify-center bg-ink/40 backdrop-blur-[var(--glass-blur)]"
       onMouseDown={(event) => {
         if (event.target === event.currentTarget) onClose();
       }}
@@ -81,7 +81,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
         aria-modal="true"
         aria-labelledby="modal-title"
         tabIndex={-1}
-        className="max-w-md rounded-sheet bg-surface-raised p-6 shadow-sheet outline-none"
+        className="max-w-md rounded-sheet border border-glass-edge bg-glass-strong p-6 shadow-glass outline-none backdrop-blur-[var(--glass-blur)]"
       >
         <h2 id="modal-title" className="mb-4 font-display text-xl font-semibold text-ink">
           {title}

--- a/app/src/components/Sheet.tsx
+++ b/app/src/components/Sheet.tsx
@@ -33,7 +33,7 @@ export function Sheet({ open, onClose, children }: SheetProps) {
   return createPortal(
     <div
       role="region"
-      className="fixed inset-x-0 bottom-0 z-sheet flex max-h-[85dvh] flex-col rounded-t-sheet bg-surface-raised p-6 shadow-sheet"
+      className="fixed inset-x-0 bottom-0 z-sheet flex max-h-[85dvh] flex-col rounded-t-sheet border border-glass-edge bg-glass-strong p-6 shadow-glass backdrop-blur-[var(--glass-blur)]"
     >
       {children}
     </div>,

--- a/app/src/engine-ui/CardStack.tsx
+++ b/app/src/engine-ui/CardStack.tsx
@@ -18,7 +18,7 @@ export function CardStack({ card, nextCard, remaining, onKeep, onDiscard }: Card
       <div className="relative">
         {nextCard ? (
           <div className="absolute inset-x-0 top-2 z-base flex justify-center opacity-60">
-            <GameCard title={nextCard.value} description={nextCard.description} size="lg" />
+            <GameCard title={nextCard.value} description={nextCard.description} />
           </div>
         ) : null}
         <div className="relative z-card">

--- a/app/src/engine-ui/KeptTray.tsx
+++ b/app/src/engine-ui/KeptTray.tsx
@@ -36,10 +36,10 @@ export function KeptTray({ cards, limit, onDemote }: KeptTrayProps) {
             Close
           </Button>
         </div>
-        <div className="mt-4 grid grid-cols-2 gap-4 overflow-y-auto sm:grid-cols-3">
+        <div className="mt-4 grid grid-cols-2 gap-4 overflow-y-auto rounded-card border border-glass-edge bg-glass p-4 shadow-glass backdrop-blur-[var(--glass-blur)] sm:grid-cols-3">
           {cards.map((card) => (
             <div key={card.value} className="flex flex-col items-center gap-2">
-              <GameCard title={card.value} description={card.description} size="sm" />
+              <GameCard title={card.value} description={card.description} />
               <Button variant="secondary" size="sm" onClick={() => onDemote(card.value)}>
                 Demote
               </Button>

--- a/app/src/engine-ui/SwipeCard.tsx
+++ b/app/src/engine-ui/SwipeCard.tsx
@@ -1,6 +1,6 @@
 import { motion, useAnimationControls, useMotionValue, useTransform } from 'framer-motion';
 import type { PanInfo } from 'framer-motion';
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 import type { Card } from '@values-cards/shared';
 import { Button } from '../components/Button';
 import { GameCard } from '../components/GameCard';
@@ -41,10 +41,6 @@ export function SwipeCard({ card, onKeep, onDiscard }: SwipeCardProps) {
   const rotate = useTransform(x, [-300, 300], [-15, 15]);
   const controls = useAnimationControls();
 
-  useEffect(() => {
-    containerRef.current?.focus();
-  }, []);
-
   async function commit(direction: 'keep' | 'discard') {
     await controls.start({ ...swipeExitTarget(direction, motionSafe), transition: transition(motionSafe, SPRING) });
     if (direction === 'keep') onKeep();
@@ -68,7 +64,7 @@ export function SwipeCard({ card, onKeep, onDiscard }: SwipeCardProps) {
       tabIndex={0}
       role="group"
       aria-label={`${card.value} card`}
-      className="flex flex-col items-center gap-4 rounded-card focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent"
+      className="flex flex-col items-center gap-4 rounded-card focus-visible:outline-none focus-visible:shadow-focus"
       onKeyDown={(event) => {
         if (event.key === 'ArrowRight') {
           event.preventDefault();
@@ -89,7 +85,7 @@ export function SwipeCard({ card, onKeep, onDiscard }: SwipeCardProps) {
         onDragEnd={(event, info) => void handleDragEnd(event, info)}
         className="cursor-grab active:cursor-grabbing"
       >
-        <GameCard title={card.value} description={card.description} size="lg" />
+        <GameCard title={card.value} description={card.description} />
       </motion.div>
       <div className="flex gap-4">
         <Button variant="danger" aria-label={`Discard ${card.value}`} onClick={() => void commit('discard')}>

--- a/app/src/engine-ui/TrimGrid.tsx
+++ b/app/src/engine-ui/TrimGrid.tsx
@@ -83,7 +83,10 @@ export function TrimGrid({ cards, cut, limit, onToggleCut, onConfirm }: TrimGrid
           {remainingToCut > 0 ? `Cut ${remainingToCut} more` : `${cards.length - cut.length} kept — ready to continue`}
         </p>
       </div>
-      <div role="list" className="grid grid-cols-2 gap-4 sm:grid-cols-3">
+      <div
+        role="list"
+        className="grid grid-cols-2 gap-4 rounded-card border border-glass-edge bg-glass p-4 shadow-glass backdrop-blur-[var(--glass-blur)] sm:grid-cols-3"
+      >
         {cards.map((card, index) => {
           const isCut = cut.includes(card.value);
           return (
@@ -100,9 +103,9 @@ export function TrimGrid({ cards, cut, limit, onToggleCut, onConfirm }: TrimGrid
               onFocus={() => setFocusIndex(index)}
               onKeyDown={(event) => onKeyDown(event, index)}
               onClick={() => onToggleCut(card.value)}
-              className={`relative flex flex-col items-center gap-2 rounded-card focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-accent ${isCut ? 'opacity-50' : ''}`}
+              className={`relative flex flex-col items-center gap-2 rounded-card focus-visible:outline-none focus-visible:shadow-focus ${isCut ? 'opacity-50' : ''}`}
             >
-              <GameCard title={card.value} description={card.description} size="sm" />
+              <GameCard title={card.value} description={card.description} />
               {isCut ? (
                 <span
                   aria-hidden="true"

--- a/app/src/engine-ui/swipe-card.test.tsx
+++ b/app/src/engine-ui/swipe-card.test.tsx
@@ -69,8 +69,8 @@ describe('SwipeCard keyboard path', () => {
     await waitFor(() => expect(onDiscard).toHaveBeenCalled(), { timeout: 3000 });
   });
 
-  it('autofocuses the card group on mount so keyboard paths work without tabbing', () => {
+  it('does not autofocus the card group on mount (no ring on initial load)', () => {
     renderCard(vi.fn(), vi.fn());
-    expect(document.activeElement).toBe(screen.getByRole('group', { name: 'Courage card' }));
+    expect(document.activeElement).not.toBe(screen.getByRole('group', { name: 'Courage card' }));
   });
 });

--- a/app/src/routes/KitchenSink.tsx
+++ b/app/src/routes/KitchenSink.tsx
@@ -9,7 +9,9 @@ import { Toast } from '../components/Toast';
 const VARIANTS: ButtonVariant[] = ['primary', 'secondary', 'ghost', 'danger'];
 
 /**
- * Dev-only showcase of every 00.3 primitive, driven only by tokens.
+ * Dev-only showcase of every glass primitive (00.4), driven only by tokens,
+ * rendered directly on the app-wide iridescent field (no opaque page
+ * background) so the frosted surfaces are visible against it.
  * Excluded from app navigation; used by E2E and visual review.
  */
 export function KitchenSink() {
@@ -17,7 +19,7 @@ export function KitchenSink() {
   const [sheetOpen, setSheetOpen] = useState(false);
 
   return (
-    <main className="flex min-h-screen flex-col gap-10 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col gap-10 p-8 text-ink">
       <h1 className="font-display text-3xl font-bold">Kitchen sink</h1>
 
       <section aria-labelledby="buttons-heading" className="flex flex-col gap-4">
@@ -38,10 +40,10 @@ export function KitchenSink() {
           Game cards
         </h2>
         <div className="flex flex-wrap items-end gap-4">
-          <GameCard size="sm" title="Courage" description="Acting despite fear" />
-          <GameCard size="md" title="Curiosity" description="Seeking to understand" />
-          <GameCard size="lg" title="Integrity" description="Consistency of values and action" />
-          <GameCard size="md" title="Trust" flipped />
+          <GameCard title="Courage" description="Acting despite fear" />
+          <GameCard title="Curiosity" description="Seeking to understand" />
+          <GameCard title="Integrity" description="Consistency of values and action" />
+          <GameCard title="Trust" flipped />
         </div>
       </section>
 

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -305,7 +305,7 @@ function SortBody({
         {finalCards.map((card, index) => (
           <li key={card.value} className="flex flex-col items-center gap-2">
             {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
-            <GameCard title={card.value} description={card.description} size="md" />
+            <GameCard title={card.value} description={card.description} />
           </li>
         ))}
       </ol>
@@ -388,7 +388,7 @@ function DemoSort() {
         {finalCards.map((card, index) => (
           <li key={card.value} className="flex flex-col items-center gap-2">
             {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
-            <GameCard title={card.value} description={card.description} size="md" />
+            <GameCard title={card.value} description={card.description} />
           </li>
         ))}
       </ol>

--- a/app/src/theme/tokens.css
+++ b/app/src/theme/tokens.css
@@ -21,6 +21,18 @@
   --color-danger: #b3261e;
   --color-success: #2e6b3e;
 
+  /* Iridescent field — light pastel stops; each passes AA with ink/ink-muted (tokens.test.ts) */
+  --color-iris-peach: #fbe4d8;
+  --color-iris-pink: #fbdce6;
+  --color-iris-lilac: #e9def8;
+  --color-iris-sky: #dcecfb;
+  --color-iris-mint: #dcf3e6;
+
+  /* Glass surfaces (rgba — allowed in theme/) */
+  --color-glass: rgb(255 255 255 / 55%);
+  --color-glass-strong: rgb(255 255 255 / 80%);
+  --color-glass-edge: rgb(255 255 255 / 65%);
+
   /* Spacing (4px base) */
   --spacing: 0.25rem;
 
@@ -33,6 +45,11 @@
   --shadow-card: 0 1px 2px rgb(38 32 27 / 0.06), 0 4px 10px rgb(38 32 27 / 0.08);
   --shadow-card-lifted: 0 4px 8px rgb(38 32 27 / 0.1), 0 12px 24px rgb(38 32 27 / 0.14);
   --shadow-sheet: 0 -4px 12px rgb(38 32 27 / 0.08), 0 -16px 40px rgb(38 32 27 / 0.16);
+  --shadow-glass: 0 8px 32px rgb(38 32 27 / 0.14), inset 0 1px 0 rgb(255 255 255 / 60%);
+  --shadow-focus: 0 0 0 3px rgb(255 255 255 / 90%), 0 0 0 6px rgb(168 70 31 / 45%);
+
+  /* Glass depth */
+  --glass-blur: 16px;
 
   /* Z-index scale (--z-index-* is Tailwind v4's namespace for the `z-*` utilities) */
   --z-index-base: 0;
@@ -45,6 +62,7 @@
   --duration-flip: 250ms;
   --duration-snap: 200ms;
   --duration-sheet: 300ms;
+  --duration-iris: 28s;
   --spring-stiffness: 420;
   --spring-damping: 32;
 
@@ -59,4 +77,43 @@
   --text-xl: 1.375rem;
   --text-2xl: 1.75rem;
   --text-3xl: 2.25rem;
+}
+
+/*
+ * App-wide iridescent field: a slow-drifting multi-stop pastel gradient
+ * behind everything. Static under prefers-reduced-motion (matches the
+ * motion.tsx contract — the same media feature, checked directly in CSS
+ * since this element is outside React).
+ */
+@layer base {
+  body {
+    min-height: 100vh;
+    background-image: linear-gradient(
+      120deg,
+      var(--color-iris-peach),
+      var(--color-iris-pink),
+      var(--color-iris-lilac),
+      var(--color-iris-sky),
+      var(--color-iris-mint),
+      var(--color-iris-peach)
+    );
+    background-size: 300% 300%;
+    animation: iris-drift var(--duration-iris) ease-in-out infinite alternate;
+  }
+
+  @keyframes iris-drift {
+    from {
+      background-position: 0% 50%;
+    }
+    to {
+      background-position: 100% 50%;
+    }
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    body {
+      animation: none;
+      background-position: 50% 50%;
+    }
+  }
 }

--- a/app/src/theme/tokens.test.ts
+++ b/app/src/theme/tokens.test.ts
@@ -17,6 +17,27 @@ function hexToRgb(hex: string): [number, number, number] {
   return [(n >> 16) & 255, (n >> 8) & 255, n & 255];
 }
 
+/** Reads a `rgb(r g b / a%)` color token (glass surfaces use this form). */
+function tokenRgba(name: string): [number, number, number, number] {
+  const match = new RegExp(
+    `--color-${name}:\\s*rgb\\((\\d+)\\s+(\\d+)\\s+(\\d+)\\s*/\\s*(\\d+)%\\)`,
+  ).exec(CSS);
+  if (!match) throw new Error(`token --color-${name} not found in tokens.css`);
+  const [, r, g, b, a] = match.map(Number);
+  return [r as number, g as number, b as number, (a as number) / 100];
+}
+
+/** Flattens a translucent color over an opaque background (both 0-255 channels). */
+function compositeOver(
+  [r, g, b, a]: [number, number, number, number],
+  bg: [number, number, number],
+): [number, number, number] {
+  const fg = [r, g, b];
+  return [0, 1, 2].map((i) => fg[i]! * a + bg[i]! * (1 - a)) as [number, number, number];
+}
+
+const IRIS_STOPS = ['iris-peach', 'iris-pink', 'iris-lilac', 'iris-sky', 'iris-mint'];
+
 function channelLuminance(c: number): number {
   const s = c / 255;
   return s <= 0.03928 ? s / 12.92 : ((s + 0.055) / 1.055) ** 2.4;
@@ -26,11 +47,16 @@ function relativeLuminance([r, g, b]: [number, number, number]): number {
   return 0.2126 * channelLuminance(r) + 0.7152 * channelLuminance(g) + 0.0722 * channelLuminance(b);
 }
 
-/** WCAG contrast ratio between two colors, order-independent. */
-function contrastRatio(hexA: string, hexB: string): number {
-  const [lumA, lumB] = [relativeLuminance(hexToRgb(hexA)), relativeLuminance(hexToRgb(hexB))];
+/** WCAG contrast ratio between two 0-255 RGB colors, order-independent. */
+function contrastRatioRgb(rgbA: [number, number, number], rgbB: [number, number, number]): number {
+  const [lumA, lumB] = [relativeLuminance(rgbA), relativeLuminance(rgbB)];
   const [lighter, darker] = lumA > lumB ? [lumA, lumB] : [lumB, lumA];
   return (lighter + 0.05) / (darker + 0.05);
+}
+
+/** WCAG contrast ratio between two hex colors, order-independent. */
+function contrastRatio(hexA: string, hexB: string): number {
+  return contrastRatioRgb(hexToRgb(hexA), hexToRgb(hexB));
 }
 
 // AA normal-text threshold is 4.5:1; large-text (≥18.66px bold / 24px regular) is 3:1.
@@ -68,6 +94,35 @@ describe('design token color pairings (WCAG AA)', () => {
 
   it('on-accent on success passes AA for normal text', () => {
     expect(contrastRatio(tokenHex('on-accent'), tokenHex('success'))).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+  });
+});
+
+describe('liquid glass token color pairings (WCAG AA)', () => {
+  for (const stop of IRIS_STOPS) {
+    it(`ink on --color-${stop} passes AA for normal text`, () => {
+      expect(contrastRatio(tokenHex('ink'), tokenHex(stop))).toBeGreaterThanOrEqual(AA_NORMAL);
+    });
+
+    it(`ink-muted on --color-${stop} passes AA for normal text`, () => {
+      expect(contrastRatio(tokenHex('ink-muted'), tokenHex(stop))).toBeGreaterThanOrEqual(
+        AA_NORMAL,
+      );
+    });
+  }
+
+  // Worst-case text-on-panel: glass-strong composited over the lightest (highest-luminance)
+  // iris stop — the panel's translucency lets the brightest possible field bleed through.
+  it('ink and ink-muted on glass-strong over the lightest iris stop pass AA for normal text', () => {
+    const lightestStop = IRIS_STOPS.map((stop) => hexToRgb(tokenHex(stop))).reduce((a, b) =>
+      relativeLuminance(a) > relativeLuminance(b) ? a : b,
+    );
+    const composited = compositeOver(tokenRgba('glass-strong'), lightestStop);
+    expect(contrastRatioRgb(hexToRgb(tokenHex('ink')), composited)).toBeGreaterThanOrEqual(
+      AA_NORMAL,
+    );
+    expect(contrastRatioRgb(hexToRgb(tokenHex('ink-muted')), composited)).toBeGreaterThanOrEqual(
       AA_NORMAL,
     );
   });

--- a/e2e/create.spec.ts
+++ b/e2e/create.spec.ts
@@ -109,6 +109,8 @@ test('facilitator created via the Create page joins the real session on /sort, n
   // And progress flows facilitator -> joiner: Coach sorts one card, Ada's roster reflects it.
   await bPage.getByRole('button', { name: /Show participants/ }).click();
   await page.locator('body').click();
+  // 00.4 removed the mount autofocus, so the card must be Tab'd to before Arrow keys reach it.
+  await page.keyboard.press('Tab');
   await page.keyboard.press('ArrowRight');
   await expect(bPage.getByRole('listitem').filter({ hasText: 'Coach' })).toContainText('1 sorted', {
     timeout: 10_000,

--- a/e2e/kitchen-sink.spec.ts
+++ b/e2e/kitchen-sink.spec.ts
@@ -25,4 +25,21 @@ for (const viewport of VIEWPORTS) {
       fullPage: true,
     });
   });
+
+  test(`every GameCard is the same width at ${viewport.name} (${viewport.width}px)`, async ({
+    page,
+  }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/kitchen-sink');
+    const cards = page.locator('[data-flipped]');
+    const count = await cards.count();
+    expect(count).toBeGreaterThan(1);
+    const widths = await Promise.all(
+      Array.from({ length: count }, (_, i) => cards.nth(i).boundingBox()),
+    );
+    const firstWidth = widths[0]?.width;
+    for (const box of widths) {
+      expect(box?.width).toBeCloseTo(firstWidth ?? 0, 0);
+    }
+  });
 }

--- a/e2e/presence.spec.ts
+++ b/e2e/presence.spec.ts
@@ -112,16 +112,24 @@ test('presence: roster membership, live progress, done, matching avatar hue, no 
   expect(adaHueDuringSort).toBe(adaHueOnB);
 
   // A sorts the whole (tiny) round: keep 2, discard 2 — no trim/rank, straight to result.
-  // Each press's swipe-exit animation must resolve (SwipeCard.commit) before the next card
-  // mounts and re-focuses itself, so waiting on the "N left" counter between presses avoids
-  // a keypress landing while no card is focused (same pattern as solo-journey.spec.ts).
+  // 00.4 removed the mount autofocus, so each new card (a remount) needs to be focused before
+  // Arrow keys reach it — the previous pattern of relying on autofocus no longer applies. This
+  // session view has roster controls ahead of the card in tab order, so focus the card group
+  // directly rather than blind-Tabbing. Each press's swipe-exit animation must resolve
+  // (SwipeCard.commit) before the next card mounts, so waiting on the "N left" counter between
+  // presses avoids a keypress landing while no card is focused.
+  const cardGroupA = pageA.getByRole('group', { name: /card$/ });
+  await cardGroupA.focus();
   await pageA.keyboard.press('ArrowRight'); // keep
   await expect(pageA.getByText('3 left')).toBeVisible({ timeout: 5000 });
   await expect(adaRowOnB).toContainText('1 sorted', { timeout: 10_000 });
+  await cardGroupA.focus();
   await pageA.keyboard.press('ArrowLeft'); // discard
   await expect(pageA.getByText('2 left')).toBeVisible({ timeout: 5000 });
+  await cardGroupA.focus();
   await pageA.keyboard.press('ArrowRight'); // keep
   await expect(pageA.getByText('1 left')).toBeVisible({ timeout: 5000 });
+  await cardGroupA.focus();
   await pageA.keyboard.press('ArrowLeft'); // discard
 
   await expect(pageA.getByRole('heading', { name: 'Presence E2E' })).toBeVisible({ timeout: 10_000 });

--- a/e2e/reduced-motion.spec.ts
+++ b/e2e/reduced-motion.spec.ts
@@ -25,6 +25,20 @@ test('GameCard flip collapses to opacity only when prefers-reduced-motion is set
   expect(['none', 'matrix(1, 0, 0, 1, 0, 0)']).toContain(transform);
 });
 
+test('iridescent field drifts when motion is allowed', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'no-preference' });
+  await page.goto('/kitchen-sink');
+  const animationName = await page.evaluate(() => getComputedStyle(document.body).animationName);
+  expect(animationName).not.toBe('none');
+});
+
+test('iridescent field is static when prefers-reduced-motion is set', async ({ page }) => {
+  await page.emulateMedia({ reducedMotion: 'reduce' });
+  await page.goto('/kitchen-sink');
+  const animationName = await page.evaluate(() => getComputedStyle(document.body).animationName);
+  expect(animationName).toBe('none');
+});
+
 test('kitchen-sink loads no third-party requests (self-hosted Fraunces)', async ({ page }) => {
   const requestOrigins = new Set<string>();
   page.on('request', (request) => {

--- a/e2e/solo-journey.spec.ts
+++ b/e2e/solo-journey.spec.ts
@@ -77,6 +77,8 @@ test('solo journey (keyboard-only): sort -> trim -> next round -> rank -> result
   // Round 1: over-keep 10 of 12 via keyboard alone.
   for (let i = 0; i < 12; i++) {
     const remainingBefore = 12 - i;
+    // 00.4 removed the mount autofocus, so each new card (a remount) needs a Tab first.
+    await page.keyboard.press('Tab');
     await page.keyboard.press(i < 10 ? 'ArrowRight' : 'ArrowLeft');
     if (remainingBefore - 1 > 0) {
       await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });
@@ -101,6 +103,7 @@ test('solo journey (keyboard-only): sort -> trim -> next round -> rank -> result
   await expect(page.getByText('8 left')).toBeVisible();
   for (let i = 0; i < 8; i++) {
     const remainingBefore = 8 - i;
+    await page.keyboard.press('Tab');
     await page.keyboard.press(i < 3 ? 'ArrowRight' : 'ArrowLeft');
     if (remainingBefore - 1 > 0) {
       await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });

--- a/e2e/sort-focus.spec.ts
+++ b/e2e/sort-focus.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from '@playwright/test';
+
+test('the active card has no focus ring on initial load (no mount autofocus)', async ({
+  page,
+}) => {
+  await page.goto('/sort');
+  const group = page.getByRole('group', { name: /card$/ });
+  await expect(group).toBeVisible();
+  const isFocused = await group.evaluate((el) => el === document.activeElement);
+  expect(isFocused).toBe(false);
+  const boxShadow = await group.evaluate((el) => getComputedStyle(el).boxShadow);
+  expect(boxShadow).toBe('none');
+});
+
+test('Tab focuses the active card and shows the shadow-focus glow', async ({ page }) => {
+  await page.goto('/sort');
+  await page.keyboard.press('Tab');
+  const group = page.getByRole('group', { name: /card$/ });
+  await expect(group).toBeFocused();
+  const boxShadow = await group.evaluate((el) => getComputedStyle(el).boxShadow);
+  expect(boxShadow).not.toBe('none');
+});

--- a/e2e/sort-keyboard.spec.ts
+++ b/e2e/sort-keyboard.spec.ts
@@ -6,6 +6,9 @@ test('completes a 12-card round using only the keyboard', async ({ page }) => {
   for (let i = 0; i < 12; i++) {
     const remainingBefore = 12 - i;
     await expect(page.getByText(`${remainingBefore} left`)).toBeVisible();
+    // 00.4 removed the mount autofocus (no ring on initial load), so each new card
+    // (a remount — CardStack keys SwipeCard by card value) must be Tab'd to first.
+    await page.keyboard.press('Tab');
     await page.keyboard.press(i % 2 === 0 ? 'ArrowRight' : 'ArrowLeft');
     if (remainingBefore - 1 > 0) {
       await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 3000 });

--- a/specs/00-foundation/00.4-liquid-glass-aesthetic.md
+++ b/specs/00-foundation/00.4-liquid-glass-aesthetic.md
@@ -80,26 +80,26 @@ query in the theme CSS, matching the `motion.tsx` contract.
   `surface`; no backdrop-blur in satori/resvg).
 
 ## Acceptance criteria
-- [ ] All new tokens (`--color-iris-*`, `--color-glass*`, `--glass-blur`, `--shadow-glass`,
+- [x] All new tokens (`--color-iris-*`, `--color-glass*`, `--glass-blur`, `--shadow-glass`,
       `--shadow-focus`, `--duration-iris`) exist in the `@theme` block; no glass/gradient/hex
       value appears outside `app/src/theme/` — `pnpm token:lint` passes.
-- [ ] `tokens.test.ts` asserts `--color-ink` and `--color-ink-muted` each ≥ 4.5:1 against
+- [x] `tokens.test.ts` asserts `--color-ink` and `--color-ink-muted` each ≥ 4.5:1 against
       **every** `--color-iris-*` stop and against `--color-glass-strong` composited over the
       lightest stop (worst-case text-on-panel), plus the 00.3 pairings still pass.
-- [ ] `GameCard` exposes no `size` prop; renders one width (`w-[min(78vw,16rem)]`) at
+- [x] `GameCard` exposes no `size` prop; renders one width (`w-[min(78vw,16rem)]`) at
       `aspect-[5/7]`; a Testing Library test asserts the single size and that all callers
       compile without a `size` prop.
-- [ ] Triage, Kept tray, trim grid, and results all render the same card dimensions — E2E
+- [x] Triage, Kept tray, trim grid, and results all render the same card dimensions — E2E
       screenshot on `/sort` (or `/kitchen-sink`) at 1440px and 390px shows uniform card size;
       Kept tray/trim containers scroll rather than shrink cards.
-- [ ] On initial load of the sort screen the active card has **no visible outline/ring**
+- [x] On initial load of the sort screen the active card has **no visible outline/ring**
       (no autofocus) — E2E asserts the container is not focused on first paint and no
       `outline`/focus ring is rendered; a keyboard Tab then shows the `--shadow-focus` glow.
-- [ ] Iridescent field renders app-wide; with `prefers-reduced-motion: reduce` emulated the
+- [x] Iridescent field renders app-wide; with `prefers-reduced-motion: reduce` emulated the
       gradient is static (no animation) — E2E via `page.emulateMedia`.
-- [ ] Glass surfaces use `backdrop-filter: blur(--glass-blur)`; text-bearing card face sits
+- [x] Glass surfaces use `backdrop-filter: blur(--glass-blur)`; text-bearing card face sits
       on a near-opaque panel (verified by the AA test above).
-- [ ] `pnpm gate` green.
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -32,7 +32,7 @@
       "depends_on": [
         "00.3"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "01.1",


### PR DESCRIPTION
Implements [specs/00-foundation/00.4-liquid-glass-aesthetic.md](specs/00-foundation/00.4-liquid-glass-aesthetic.md). Re-skins the base visual system to "liquid glass": an iridescent pastel field, frosted-glass surfaces, one card size everywhere, and removal of the initial-load focus ring. Supersedes 00.3's tactile-warm base; per-session theming (03.3) layers on top.

## Verified visually
`/kitchen-sink` captured at 1440px and 390px — iridescent field renders app-wide, cards are uniform size and stack correctly on mobile, text sits on near-opaque panels (legible), all primitives intact. (Screenshots reviewed before merge.)

## Token values chosen
- Iris stops: peach `#fbe4d8`, pink `#fbdce6`, lilac `#e9def8`, sky `#dcecfb`, mint `#dcf3e6`.
- Glass: `--color-glass` white/55%, `--color-glass-strong` white/80%, `--color-glass-edge` white/65%; `--glass-blur: 16px`; `--shadow-glass`, `--shadow-focus` (soft glow), `--duration-iris: 28s`.

## Invariant 6 (WCAG AA) — real assertions
`tokens.test.ts` computes actual WCAG ratios (with alpha compositing) for `ink` and `ink-muted` against **every** iris stop and against `glass-strong` composited over the lightest stop:
- worst case ink-muted vs a stop: **4.86:1** (pink) — above 4.5.
- glass-strong over lightest stop: ink 15.5:1, ink-muted 5.96:1.
- 00.3 pairings still asserted and passing.

## Accessibility (hard gate)
- No autofocus ring on initial load: `swipe-card.test.tsx` + `e2e/sort-focus.spec.ts` assert the card group isn't focused on first paint.
- Keyboard focus still visible: `e2e/sort-focus.spec.ts` asserts Tab focuses the card and renders the `--shadow-focus` glow (`boxShadow !== 'none'`).
- Reduced motion: `e2e/reduced-motion.spec.ts` asserts the field's `animationName` is static under `prefers-reduced-motion: reduce`, animated otherwise.

## Existing tests corrected for the new look (not loosened)
- `swipe-card.test.tsx`: "autofocuses on mount" → "does not autofocus" (spec removes it).
- `GameCard.test.tsx`: sm/md/lg loop → single canonical-size assertion (the `size` prop is gone).
- `sort-keyboard`, `solo-journey`, `create`, `presence` e2e: added an explicit Tab/`.focus()` before Arrow keypresses, since cards no longer autofocus on (re)mount — without it the keyboard flows would silently no-op. This is a real consequence of removing autofocus, handled correctly rather than papered over.
- `kitchen-sink.spec.ts`: added a uniform-card-width assertion across all rendered cards.

## Deviations
- "KeptTray/TrimGrid containers adopt the glass fill" applied to their grid wrapper divs, not the page `<main>` (page backgrounds weren't in the spec's file list).
- `RankBoard`'s `bg-surface-raised` left untouched — the spec's out-of-scope says its surface *may* pick up glass, not must; kept the smaller diff.

## Test evidence
`pnpm gate` green, verified independently in a clean install:
```
Test Files  39 passed (39)
     Tests  271 passed (271)
  64 passed (1.1m)   [desktop-chromium + mobile-chromium]
```

## Note on look
The glass reads intentionally subtle — near-opaque panels are the spec's chosen mechanism for guaranteeing text contrast, so it's a gentle iridescence rather than heavy frosting. If a bolder glass effect is wanted, that's a token tweak in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)