### PR TITLE
fix(00.4): let the iridescent field show — routes covered it with bg-surface

### DIFF
--- a/app/src/routes/Create.tsx
+++ b/app/src/routes/Create.tsx
@@ -54,7 +54,7 @@ export function Create() {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-3xl font-semibold">Start a game</h1>
 
       <label className="flex w-full max-w-sm flex-col gap-1 text-sm font-semibold" htmlFor="creator-name">
@@ -144,7 +144,7 @@ function CreateLobby({ code, creatorToken, name }: { code: string; creatorToken:
   const token = loadToken(code);
   if (!state || !token || !state.participants[token.participantId]) {
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-ink">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-ink">
         <ConnectionPill connection={connection} />
         <h1 className="font-display text-2xl font-semibold">Creating your game…</h1>
       </main>

--- a/app/src/routes/Join.tsx
+++ b/app/src/routes/Join.tsx
@@ -56,7 +56,7 @@ export function Join({ code: initialCode }: JoinProps) {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-ink">
       <h1 className="font-display text-3xl font-semibold">Join a game</h1>
       <form onSubmit={submit} className="flex w-full max-w-sm flex-col gap-4">
         <label className="flex flex-col gap-1 text-sm font-semibold" htmlFor="session-code">
@@ -144,7 +144,7 @@ function JoiningSession({ code, name }: { code: string; name: string }) {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-ink">
       <ConnectionPill connection={connection} />
       <h1 className="font-display text-2xl font-semibold">Joining {code}…</h1>
       {alreadyJoined ? <p className="text-ink-muted">Resuming your session.</p> : null}

--- a/app/src/routes/Landing.tsx
+++ b/app/src/routes/Landing.tsx
@@ -1,6 +1,6 @@
 export function Landing() {
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-8 bg-surface text-ink">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-8 text-ink">
       <h1 className="text-5xl font-bold tracking-tight">Values Cards</h1>
       <p className="text-ink-muted">Sort what matters. Keep what counts.</p>
       <nav aria-label="Get started" className="flex gap-4">

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -96,7 +96,7 @@ function SessionSort({ code }: { code: string }) {
 
   if (!token || !state) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-surface text-ink">
+      <main className="flex min-h-screen items-center justify-center text-ink">
         <ConnectionPill connection={connection} />
         <p>Loading…</p>
       </main>
@@ -106,7 +106,7 @@ function SessionSort({ code }: { code: string }) {
   const me = state.participants[token.participantId];
   if (!me) {
     return (
-      <main className="flex min-h-screen items-center justify-center bg-surface text-ink">
+      <main className="flex min-h-screen items-center justify-center text-ink">
         <ConnectionPill connection={connection} />
         <p>Loading…</p>
       </main>
@@ -135,7 +135,7 @@ function Lobby({ state, participantId, send }: { state: SessionState; participan
   const canStart = !state.config.facilitated || me?.role === 'facilitator';
 
   return (
-    <main className="flex min-h-screen flex-col items-center justify-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
       <p className="text-ink-muted">Waiting to start · code {state.code}</p>
       {/* 03.1 requires a joined participant to see the game's config in its lobby, and to
@@ -258,7 +258,7 @@ function SortBody({
     const roundCfg = config.rounds[state.round - 1];
     const setAside = state.totalDiscarded + state.discarded.length;
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-center text-ink">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-ink">
         <h1 className="font-display text-2xl font-semibold">{roundCfg?.name} complete</h1>
         <p className="text-ink-muted">
           {state.kept.length} kept · {setAside} set aside
@@ -298,7 +298,7 @@ function SortBody({
   const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
   const isRanked = finalRoundCfg?.rank === true;
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{config.title}</h1>
       <p className="text-ink-muted">Your final cards</p>
       <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">
@@ -342,7 +342,7 @@ function DemoSort() {
     const roundCfg = DEMO_CONFIG.rounds[state.round - 1];
     const setAside = state.totalDiscarded + state.discarded.length;
     return (
-      <main className="flex min-h-screen flex-col items-center justify-center gap-4 bg-surface p-8 text-center text-ink">
+      <main className="flex min-h-screen flex-col items-center justify-center gap-4 p-8 text-center text-ink">
         <h1 className="font-display text-2xl font-semibold">{roundCfg?.name} complete</h1>
         <p className="text-ink-muted">
           {state.kept.length} kept · {setAside} set aside
@@ -381,7 +381,7 @@ function DemoSort() {
   const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
   const isRanked = DEMO_CONFIG.rounds[DEMO_CONFIG.rounds.length - 1]?.rank === true;
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{DEMO_CONFIG.title}</h1>
       <p className="text-ink-muted">Your final cards</p>
       <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">

--- a/app/src/routes/lobby.tsx
+++ b/app/src/routes/lobby.tsx
@@ -48,7 +48,7 @@ export function Lobby({ code, state, participantId, send }: LobbyProps) {
   const draftValid = validateConfig(draft).ok;
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-8 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-8 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
 
       <section className="flex flex-col items-center gap-3">

--- a/e2e/smoke.spec.ts
+++ b/e2e/smoke.spec.ts
@@ -6,3 +6,24 @@ test('landing page renders the Values Cards placeholder', async ({ page }) => {
   await expect(page.getByRole('link', { name: 'Start a session' })).toBeVisible();
   await expect(page.getByRole('link', { name: 'Join a session' })).toBeVisible();
 });
+
+// Regression: 00.4 put the iridescent field on `body`, but every route's full-screen
+// `<main>` kept an opaque `bg-surface`, painting the field over on every real screen —
+// so the app looked like the old warm theme everywhere except /kitchen-sink. The field
+// existing on body isn't enough; a real route must not cover it.
+test('the iridescent field is actually visible on the landing route (not covered by main)', async ({ page }) => {
+  await page.goto('/');
+  const field = await page.evaluate(() => {
+    const main = document.querySelector('main');
+    const toRgba = (c: string) => c.replace(/\s+/g, '');
+    return {
+      bodyGradient: getComputedStyle(document.body).backgroundImage,
+      mainBg: main ? toRgba(getComputedStyle(main).backgroundColor) : 'no-main',
+    };
+  });
+  // The body carries the iridescent gradient...
+  expect(field.bodyGradient).toContain('gradient');
+  // ...and the top-level main must be transparent, so the field shows through rather than
+  // being hidden behind an opaque surface fill.
+  expect(['rgba(0,0,0,0)', 'transparent']).toContain(field.mainBg);
+});


### PR DESCRIPTION
User-reported: the liquid-glass theme from #52 "didn't take" — every screen still looked like the old warm theme.

## Cause
00.4 applied the iridescent field to `body` and updated `/kitchen-sink`, but **every real route's full-screen `<main>` kept an opaque `bg-surface`** (the 00.3 warm cream), painting straight over the field. `/kitchen-sink` was the *only* page without `bg-surface` on its main.

That's also why my own visual check missed it: I screenshotted `/kitchen-sink` (field visible) and concluded it shipped — but Landing, Create, Join, lobby, and Sort all rendered warm cream (`rgb(250,246,238)`). My verification was a false positive; I should have shot a real route. Confirmed on latest `v2` with a clean server before fixing.

## Fix
- Drop the standalone `bg-surface` from the 5 routes' top-level `<main>` elements (13 occurrences) so the body field shows through. Text on these screens is `ink`/`ink-muted`, which 00.4's AA test already proves passes over every iris stop. `bg-surface-raised` panels are untouched (still near-opaque and legible).

## Regression test
The 00.4 e2e only asserted `body`'s `animationName` — it never checked that a real route *shows* the field, which is why the opaque cover slipped through green. Added to `e2e/smoke.spec.ts`: on `/`, assert the body carries the gradient **and** `<main>` is transparent (not covering it).

**Verified it fails without the fix** — `Expected: "rgb(250,246,238)"` vs `["rgba(0,0,0,0)","transparent"]` — and passes with it.

## Evidence
Field confirmed visible on Landing at 1440px (transparent main, body gradient, legible text) via screenshot. Gate green:
```
Test Files  39 passed (39)
     Tests  271 passed (271)
  66 passed (1.2m)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)