### PR TITLE
fix(03.1): make the create-game failure message diagnostic

### DIFF
--- a/app/src/routes/Create.tsx
+++ b/app/src/routes/Create.tsx
@@ -38,12 +38,23 @@ export function Create() {
         headers: { 'content-type': 'application/json' },
         body: JSON.stringify({ config }),
       });
-      if (!response.ok) throw new Error('create failed');
+      if (!response.ok) {
+        // A 502/503/504 means Vite proxied /api to a game server that isn't answering —
+        // almost always the party dev server not running. Say so, instead of a generic
+        // "try again" that sent people re-clicking a button that can't work.
+        setCreateError(
+          response.status >= 502
+            ? 'Can’t reach the game server. Is it running? (dev: pnpm dev in party/)'
+            : `The server rejected these settings (${response.status}). Adjust and try again.`,
+        );
+        return;
+      }
       const body = (await response.json()) as { code: string; creatorToken: string };
       localStorage.setItem(CREATOR_TOKEN_KEY(body.code), body.creatorToken);
       setCreated(body);
     } catch {
-      setCreateError('Could not create a game. Try again.');
+      // fetch itself threw — network unreachable, not a rejected request.
+      setCreateError('Can’t reach the game server. Check your connection and try again.');
     } finally {
       setCreating(false);
     }


### PR DESCRIPTION
Reported: "Could not create a game. Try again." when creating a custom game as facilitator (Dev 12 deck, Open triage → Top7 keep 7 → Top 3 keep 3 ranked).

## It's not the config — it's the server being unreachable
The exact config POSTs **200** directly to the DO, and creates cleanly in-browser when both dev servers are up. Reproduced the failure: with the party (wrangler) dev server **down**, the browser's `POST /api/session` gets a **502** from Vite's `/api` proxy, and the old generic message fired — hiding the real cause and inviting pointless re-clicks.

This is the second time a create-path failure surfaced with a message that gave no way to diagnose it (the first was the missing `.dev.vars` secret). Fixing the message so the cause is legible:
- **502/503/504** → "Can't reach the game server. Is it running? (dev: pnpm dev in party/)"
- other non-ok → "The server rejected these settings (`status`)."
- fetch throws (network) → "Can't reach the game server. Check your connection."

## Verified
- party down → button shows the "is it running?" message (browser-checked).
- party up → create still succeeds (200).

```
Test Files  39 passed (39)
     Tests  271 passed (271)
  66 passed (1.1m)
```

The `[WebServer] internal error` console lines are Miniflare teardown noise — all 66 e2e passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)