### PR TITLE
feat(00.5): Glass design system applied app-wide

### DIFF
--- a/app/src/components/GameCard.tsx
+++ b/app/src/components/GameCard.tsx
@@ -39,7 +39,7 @@ export function GameCard({ title, description, flipped = false }: GameCardProps)
   return (
     <motion.div
       data-flipped={flipped}
-      className={`${CARD_SIZE} rounded-card border border-glass-edge bg-glass shadow-glass backdrop-blur-[var(--glass-blur)]`}
+      className={`${CARD_SIZE} rounded-card glass-panel`}
       variants={variants}
       initial={flipped ? 'back' : 'front'}
       animate={flipped ? 'back' : 'front'}

--- a/app/src/components/Modal.tsx
+++ b/app/src/components/Modal.tsx
@@ -81,7 +81,7 @@ export function Modal({ open, onClose, title, children }: ModalProps) {
         aria-modal="true"
         aria-labelledby="modal-title"
         tabIndex={-1}
-        className="max-w-md rounded-sheet border border-glass-edge bg-glass-strong p-6 shadow-glass outline-none backdrop-blur-[var(--glass-blur)]"
+        className="max-w-md rounded-sheet glass-panel-strong p-6 outline-none"
       >
         <h2 id="modal-title" className="mb-4 font-display text-xl font-semibold text-ink">
           {title}

--- a/app/src/components/Roster.tsx
+++ b/app/src/components/Roster.tsx
@@ -57,7 +57,7 @@ export function Roster({ participants, selfId, collapsible = false }: RosterProp
 
   if (!collapsible || expanded) {
     return (
-      <div>
+      <div className="glass-panel-strong rounded-control p-3">
         {collapsible ? (
           <button type="button" onClick={() => setExpanded(false)} className="mb-2 text-sm font-semibold text-ink-muted">
             Hide participants

--- a/app/src/components/Sheet.tsx
+++ b/app/src/components/Sheet.tsx
@@ -33,7 +33,7 @@ export function Sheet({ open, onClose, children }: SheetProps) {
   return createPortal(
     <div
       role="region"
-      className="fixed inset-x-0 bottom-0 z-sheet flex max-h-[85dvh] flex-col rounded-t-sheet border border-glass-edge bg-glass-strong p-6 shadow-glass backdrop-blur-[var(--glass-blur)]"
+      className="fixed inset-x-0 bottom-0 z-sheet flex max-h-[85dvh] flex-col rounded-t-sheet glass-panel-strong p-6"
     >
       {children}
     </div>,

--- a/app/src/components/Toast.tsx
+++ b/app/src/components/Toast.tsx
@@ -4,7 +4,7 @@ export interface ToastProps {
 }
 
 const VARIANT_CLASSES: Record<NonNullable<ToastProps['variant']>, string> = {
-  default: 'bg-ink text-surface',
+  default: 'glass-panel-strong text-ink',
   danger: 'bg-danger text-on-accent',
   success: 'bg-success text-on-accent',
 };

--- a/app/src/engine-ui/KeptTray.tsx
+++ b/app/src/engine-ui/KeptTray.tsx
@@ -36,7 +36,7 @@ export function KeptTray({ cards, limit, onDemote }: KeptTrayProps) {
             Close
           </Button>
         </div>
-        <div className="mt-4 grid grid-cols-2 gap-4 overflow-y-auto rounded-card border border-glass-edge bg-glass p-4 shadow-glass backdrop-blur-[var(--glass-blur)] sm:grid-cols-3">
+        <div className="mt-4 grid grid-cols-2 gap-4 overflow-y-auto rounded-card glass-panel p-4 sm:grid-cols-3">
           {cards.map((card) => (
             <div key={card.value} className="flex flex-col items-center gap-2">
               <GameCard title={card.value} description={card.description} />

--- a/app/src/engine-ui/RankBoard.tsx
+++ b/app/src/engine-ui/RankBoard.tsx
@@ -109,7 +109,7 @@ export function RankBoard({ cards, onReorder, onConfirm }: RankBoardProps) {
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">Rank your final cards</h1>
       <p className="text-sm text-ink-muted">Drag to reorder, most important first.</p>
       <DndContext

--- a/app/src/engine-ui/SortRound.tsx
+++ b/app/src/engine-ui/SortRound.tsx
@@ -63,7 +63,7 @@ export function SortRound({ config, useSortStore }: SortRoundProps) {
   }, [useSortStore]);
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-8 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-8 p-8 text-ink">
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}
       </div>

--- a/app/src/engine-ui/TrimGrid.tsx
+++ b/app/src/engine-ui/TrimGrid.tsx
@@ -73,7 +73,7 @@ export function TrimGrid({ cards, cut, limit, onToggleCut, onConfirm }: TrimGrid
   }
 
   return (
-    <main className="flex min-h-screen flex-col items-center gap-6 bg-surface p-8 text-ink">
+    <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <div aria-live="polite" role="status" className="sr-only">
         {announcement}
       </div>
@@ -85,7 +85,7 @@ export function TrimGrid({ cards, cut, limit, onToggleCut, onConfirm }: TrimGrid
       </div>
       <div
         role="list"
-        className="grid grid-cols-2 gap-4 rounded-card border border-glass-edge bg-glass p-4 shadow-glass backdrop-blur-[var(--glass-blur)] sm:grid-cols-3"
+        className="grid grid-cols-2 gap-4 rounded-card glass-panel p-4 sm:grid-cols-3"
       >
         {cards.map((card, index) => {
           const isCut = cut.includes(card.value);

--- a/app/src/routes/Create.tsx
+++ b/app/src/routes/Create.tsx
@@ -74,12 +74,12 @@ export function Create() {
           id="creator-name"
           value={name}
           onChange={(event) => setName(event.target.value)}
-          className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+          className="rounded-control border border-ink-muted glass-panel-strong px-3 py-2 text-ink"
         />
       </label>
 
       {!customizing ? (
-        <section className="flex w-full max-w-sm flex-col gap-3 rounded-control border border-ink-muted bg-surface-raised p-4">
+        <section className="flex w-full max-w-sm flex-col gap-3 rounded-control border border-ink-muted glass-panel-strong p-4">
           <h2 className="font-display text-xl font-semibold">{config.title}</h2>
           <p className="text-sm text-ink-muted">
             {config.deck.name} ({config.deck.cards.length} cards) · {config.rounds.map((round) => round.name).join(' → ')}

--- a/app/src/routes/Join.tsx
+++ b/app/src/routes/Join.tsx
@@ -67,7 +67,7 @@ export function Join({ code: initialCode }: JoinProps) {
             onChange={(event) => setCode(event.target.value.toUpperCase())}
             maxLength={6}
             required
-            className="rounded-control border border-ink-muted bg-surface-raised px-4 py-2 text-lg uppercase tracking-widest text-ink"
+            className="rounded-control border border-ink-muted glass-panel-strong px-4 py-2 text-lg uppercase tracking-widest text-ink"
           />
         </label>
         <label className="flex flex-col gap-1 text-sm font-semibold" htmlFor="display-name">
@@ -77,7 +77,7 @@ export function Join({ code: initialCode }: JoinProps) {
             value={name}
             onChange={(event) => setName(event.target.value)}
             required
-            className="rounded-control border border-ink-muted bg-surface-raised px-4 py-2 text-ink"
+            className="rounded-control border border-ink-muted glass-panel-strong px-4 py-2 text-ink"
           />
         </label>
         <Button type="submit">Join</Button>

--- a/app/src/routes/create/deck-picker.tsx
+++ b/app/src/routes/create/deck-picker.tsx
@@ -28,7 +28,7 @@ export function DeckPicker({ decks = BUNDLED_DECKS, selected, onSelect, disabled
             <label
               key={deck.name}
               htmlFor={id}
-              className={`flex flex-1 cursor-pointer flex-col gap-1 rounded-control border p-4 ${isSelected ? 'border-accent bg-accent-subtle' : 'border-ink-muted bg-surface-raised'}`}
+              className={`flex flex-1 cursor-pointer flex-col gap-1 rounded-control border p-4 ${isSelected ? 'border-accent bg-accent-subtle' : 'border-ink-muted glass-panel-strong'}`}
             >
               <span className="flex items-center gap-2 font-semibold text-ink">
                 <input id={id} type="radio" name="deck" checked={isSelected} onChange={() => onSelect(deck)} />

--- a/app/src/routes/create/designer.tsx
+++ b/app/src/routes/create/designer.tsx
@@ -34,7 +34,7 @@ export function Designer({
           value={config.title}
           onChange={(event) => onTitleChange(event.target.value)}
           disabled={disabled}
-          className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+          className="rounded-control border border-ink-muted glass-panel-strong px-3 py-2 text-ink"
         />
       </label>
 

--- a/app/src/routes/create/round-editor.tsx
+++ b/app/src/routes/create/round-editor.tsx
@@ -63,7 +63,7 @@ export function RoundEditor({ rounds, deckSize, errors, onChange, disabled = fal
           const keepAny = round.keep === 'any';
 
           return (
-            <div key={index} className="flex flex-col gap-2 rounded-control border border-ink-muted p-4">
+            <div key={index} className="flex flex-col gap-2 rounded-control border border-ink-muted glass-panel-strong p-4">
               <div className="flex items-end gap-3">
                 <label className="flex flex-1 flex-col gap-1 text-sm font-semibold" htmlFor={`round-${index}-name`}>
                   Round {index + 1} name
@@ -71,7 +71,7 @@ export function RoundEditor({ rounds, deckSize, errors, onChange, disabled = fal
                     id={`round-${index}-name`}
                     value={round.name}
                     onChange={(event) => updateRound(index, { name: event.target.value })}
-                    className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+                    className="rounded-control border border-ink-muted glass-panel-strong px-3 py-2 text-ink"
                   />
                 </label>
                 <Button
@@ -111,7 +111,7 @@ export function RoundEditor({ rounds, deckSize, errors, onChange, disabled = fal
                     onChange={(event) => updateRound(index, { keep: Number(event.target.value) || 0 })}
                     aria-describedby={keepErrors.length > 0 ? `round-${index}-keep-error` : undefined}
                     aria-invalid={keepErrors.length > 0}
-                    className="w-32 rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-ink"
+                    className="w-32 rounded-control border border-ink-muted glass-panel-strong px-3 py-2 text-ink"
                   />
                 </label>
               ) : null}

--- a/app/src/routes/lobby.tsx
+++ b/app/src/routes/lobby.tsx
@@ -49,51 +49,53 @@ export function Lobby({ code, state, participantId, send }: LobbyProps) {
 
   return (
     <main className="flex min-h-screen flex-col items-center gap-8 p-8 text-ink">
-      <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
+      <div className="glass-panel-strong flex w-full max-w-md flex-col items-center gap-8 rounded-sheet p-8">
+        <h1 className="font-display text-2xl font-semibold">{state.config.title}</h1>
 
-      <section className="flex flex-col items-center gap-3">
-        <p className="font-display text-5xl font-bold tracking-widest">{code}</p>
-        <div className="flex items-center gap-2">
-          <input readOnly value={shareLink} aria-label="Share link" className="rounded-control border border-ink-muted bg-surface-raised px-3 py-2 text-sm text-ink" />
-          <Button type="button" variant="secondary" size="sm" onClick={copyLink}>
-            Copy link
-          </Button>
-        </div>
-        {copied ? <Toast message="Link copied" variant="success" /> : null}
-      </section>
+        <section className="flex flex-col items-center gap-3">
+          <p className="font-display text-5xl font-bold tracking-widest">{code}</p>
+          <div className="flex items-center gap-2">
+            <input readOnly value={shareLink} aria-label="Share link" className="rounded-control border border-ink-muted glass-panel-strong px-3 py-2 text-sm text-ink" />
+            <Button type="button" variant="secondary" size="sm" onClick={copyLink}>
+              Copy link
+            </Button>
+          </div>
+          {copied ? <Toast message="Link copied" variant="success" /> : null}
+        </section>
 
-      <section className="w-full max-w-md text-center">
-        <h2 className="mb-2 font-display text-lg font-semibold">Game</h2>
-        <p className="text-sm text-ink-muted">
-          {state.config.deck.name} ({state.config.deck.cards.length} cards) ·{' '}
-          {state.config.rounds.map((round) => round.name).join(' → ')}
-        </p>
-      </section>
+        <section className="w-full text-center">
+          <h2 className="mb-2 font-display text-lg font-semibold">Game</h2>
+          <p className="text-sm text-ink-muted">
+            {state.config.deck.name} ({state.config.deck.cards.length} cards) ·{' '}
+            {state.config.rounds.map((round) => round.name).join(' → ')}
+          </p>
+        </section>
 
-      <section className="w-full max-w-md">
-        <h2 className="mb-2 font-display text-lg font-semibold">Players</h2>
-        <ul className="flex flex-col gap-2">
-          {Object.entries(state.participants).map(([id, participant]) => (
-            <li key={id} className="flex items-center justify-between rounded-control border border-ink-muted bg-surface-raised px-3 py-2">
-              <span>{participant.name}</span>
-              <span className="text-sm text-ink-muted">{participant.role === 'facilitator' ? 'Facilitator' : 'Participant'}</span>
-            </li>
-          ))}
-        </ul>
-      </section>
+        <section className="w-full">
+          <h2 className="mb-2 font-display text-lg font-semibold">Players</h2>
+          <ul className="flex flex-col gap-2">
+            {Object.entries(state.participants).map(([id, participant]) => (
+              <li key={id} className="flex items-center justify-between rounded-control border border-ink-muted glass-panel-strong px-3 py-2">
+                <span>{participant.name}</span>
+                <span className="text-sm text-ink-muted">{participant.role === 'facilitator' ? 'Facilitator' : 'Participant'}</span>
+              </li>
+            ))}
+          </ul>
+        </section>
 
-      {state.phase !== 'lobby' ? <p className="text-ink-muted">Config is locked — the game has started.</p> : null}
+        {state.phase !== 'lobby' ? <p className="text-ink-muted">Config is locked — the game has started.</p> : null}
 
-      {isFacilitator && state.phase === 'lobby' ? (
-        <div className="flex gap-4">
-          <Button type="button" variant="secondary" onClick={openEditor}>
-            Edit game
-          </Button>
-          <Button type="button" onClick={() => send(intents.startGame(participantId))}>
-            Start game
-          </Button>
-        </div>
-      ) : null}
+        {isFacilitator && state.phase === 'lobby' ? (
+          <div className="flex gap-4">
+            <Button type="button" variant="secondary" onClick={openEditor}>
+              Edit game
+            </Button>
+            <Button type="button" onClick={() => send(intents.startGame(participantId))}>
+              Start game
+            </Button>
+          </div>
+        ) : null}
+      </div>
 
       <Modal open={editing} onClose={() => setEditing(false)} title="Edit game">
         <div className="flex max-h-[70vh] flex-col gap-6 overflow-y-auto">

--- a/app/src/theme/glass-coverage.test.ts
+++ b/app/src/theme/glass-coverage.test.ts
@@ -1,0 +1,43 @@
+import { readFileSync, readdirSync, statSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// 00.5: glass is the one system-wide surface — no app screen may fall back to the
+// opaque 00.3 `bg-surface-raised` panel where a themed surface is intended.
+const APP_SRC = join(dirname(fileURLToPath(import.meta.url)), '..');
+
+function collectFiles(dir: string, files: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      collectFiles(fullPath, files);
+    } else if (/\.tsx?$/.test(entry)) {
+      files.push(fullPath);
+    }
+  }
+  return files;
+}
+
+function violations(files: string[]): string[] {
+  const hits: string[] = [];
+  for (const file of files) {
+    readFileSync(file, 'utf8')
+      .split('\n')
+      .forEach((line, index) => {
+        if (line.includes('bg-surface-raised')) hits.push(`${file}:${index + 1}`);
+      });
+  }
+  return hits;
+}
+
+describe('glass surface coverage', () => {
+  it('no bare bg-surface-raised remains under app/src/routes/**', () => {
+    expect(violations(collectFiles(join(APP_SRC, 'routes')))).toEqual([]);
+  });
+
+  it('no bare bg-surface-raised remains in Roster.tsx or Toast.tsx', () => {
+    const files = [join(APP_SRC, 'components', 'Roster.tsx'), join(APP_SRC, 'components', 'Toast.tsx')];
+    expect(violations(files)).toEqual([]);
+  });
+});

--- a/app/src/theme/tokens.css
+++ b/app/src/theme/tokens.css
@@ -117,3 +117,27 @@
     }
   }
 }
+
+/*
+ * The one glass surface, composed everywhere a panel is needed (00.5). Screens apply
+ * `.glass-panel` / `.glass-panel-strong` rather than re-assembling fill + blur + edge +
+ * shadow from raw utilities — that fragmentation is exactly what left most of 00.4's
+ * screens on opaque `bg-surface-raised`. Text-bearing panels use `-strong` so
+ * `--color-ink`/`--color-ink-muted` keep AA (tokens.test.ts).
+ */
+@layer components {
+  .glass-panel,
+  .glass-panel-strong {
+    border: 1px solid var(--color-glass-edge);
+    box-shadow: var(--shadow-glass);
+    backdrop-filter: blur(var(--glass-blur));
+  }
+
+  .glass-panel {
+    background-color: var(--color-glass);
+  }
+
+  .glass-panel-strong {
+    background-color: var(--color-glass-strong);
+  }
+}

--- a/e2e/glass-coverage.spec.ts
+++ b/e2e/glass-coverage.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from '@playwright/test';
+
+const VIEWPORTS = [
+  { name: 'desktop', width: 1440, height: 900 },
+  { name: 'mobile', width: 390, height: 844 },
+];
+
+// 00.5: glass is a system, not a handful of sort-flow primitives — /create's template
+// summary panel and a real lobby (creator's, via /create -> Create game) must both render
+// translucent, blurred glass on the iridescent field, at both a desktop and mobile viewport.
+for (const viewport of VIEWPORTS) {
+  test(`/create's template panel is glass (blurred, translucent) at ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/create');
+    const panel = page.locator('section', { hasText: 'Customize' });
+    await expect(panel).toBeVisible();
+    const backdropFilter = await panel.evaluate((el) => getComputedStyle(el).backdropFilter);
+    expect(backdropFilter).toContain('blur');
+    expect(backdropFilter).not.toBe('none');
+  });
+
+  test(`the creator's lobby panel is glass (blurred, translucent) at ${viewport.name}`, async ({ page }) => {
+    await page.setViewportSize({ width: viewport.width, height: viewport.height });
+    await page.goto('/create');
+    await page.getByLabel('Your name').fill('Coach');
+    await page.getByRole('button', { name: 'Create game' }).click();
+    const shareLink = page.getByLabel('Share link');
+    await expect(shareLink).toHaveValue(/\/join\/[A-Z0-9]{6}$/, { timeout: 10_000 });
+
+    const backdropFilter = await shareLink.evaluate((el) => getComputedStyle(el).backdropFilter);
+    expect(backdropFilter).toContain('blur');
+    expect(backdropFilter).not.toBe('none');
+  });
+}

--- a/specs/00-foundation/00.5-glass-system-app-wide.md
+++ b/specs/00-foundation/00.5-glass-system-app-wide.md
@@ -55,21 +55,26 @@ surface, keeping the 00.3 tokens for spacing/radius/text:
   those token values are 00.4's; this spec is coverage, not re-tuning.
 
 ## Acceptance criteria
-- [ ] A single glass surface definition exists in `app/src/theme/` (`.glass-panel` /
+- [x] A single glass surface definition exists in `app/src/theme/` (`.glass-panel` /
       `.glass-panel-strong`), composing only existing 00.4 tokens; `pnpm token:lint` passes
       (no raw glass/blur/hex outside `theme/`).
-- [ ] No app surface renders on bare `bg-surface-raised`: a test (unit or grep-style check)
+- [x] No app surface renders on bare `bg-surface-raised`: a test (unit or grep-style check)
       asserts `bg-surface-raised` no longer appears in `app/src/routes/**` or
       `app/src/components/{Roster,Toast}.tsx` — those compose the glass class instead.
-- [ ] `tokens.test.ts` AA assertions still pass, extended to any new text-on-glass pairing
+- [x] `tokens.test.ts` AA assertions still pass, extended to any new text-on-glass pairing
       introduced; `--color-ink`/`--color-ink-muted` ≥ 4.5:1 on every text-bearing glass
-      surface.
-- [ ] E2E screenshot review: `/create` and a lobby both render glass panels on the
-      iridescent field (not opaque white) at 1440px and 390px — panels are translucent
-      (their computed `backdrop-filter` is a blur, not `none`).
-- [ ] Keyboard focus still uses the `--shadow-focus` glow app-wide (a11y gate); no screen
-      regresses to a hard outline.
-- [ ] `pnpm gate` green.
+      surface. (No new pairing: every text-bearing surface uses the existing
+      `--color-glass-strong` token, whose worst-case-over-iris AA is already asserted; nesting
+      it inside another `glass-panel-strong` only increases opacity, never regresses contrast.)
+- [x] E2E screenshot review: computed-style assertion added (`e2e/glass-coverage.spec.ts`)
+      asserting `backdrop-filter` is a blur (not `none`) on `/create`'s template panel and the
+      creator's lobby share-link field at 1440px and 390px; a human/orchestrator screenshot
+      pass is still the visual check.
+- [x] Keyboard focus still uses the `--shadow-focus` glow app-wide (a11y gate); no screen
+      regresses to a hard outline. (Verified by grep: no `outline-accent` or
+      `focus-visible:outline-2` remains anywhere in `app/src`; this spec touched no
+      focus-visible classes.)
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -42,7 +42,7 @@
         "00.3",
         "00.4"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "01.1",


### PR DESCRIPTION
Implements [specs/00-foundation/00.5-glass-system-app-wide.md](specs/00-foundation/00.5-glass-system-app-wide.md). Makes the liquid-glass look a system that covers the whole app, per user feedback that 00.4 left the create/designer/lobby screens on plain opaque panels.

## The fix: one glass surface, composed everywhere
Defined **once** in `app/src/theme/tokens.css` as an `@layer components` rule — `.glass-panel` and `.glass-panel-strong` (text-bearing), both composing existing 00.4 tokens (`--color-glass*`, `--glass-blur`, `--color-glass-edge`, `--shadow-glass`). No new tokens.

Applied to every surface 00.4 missed: `Create.tsx`, `Join.tsx` inputs, `lobby.tsx` (panel + share link + roster rows), `create/deck-picker.tsx`, `create/round-editor.tsx`, `create/designer.tsx`, `components/Roster.tsx`, `components/Toast.tsx` (default variant only — semantic danger/success stay solid). The 00.4 primitives (`GameCard`, `Sheet`, `Modal`, `TrimGrid`, `KeptTray`) were **refactored onto the same class** so there's genuinely one glass definition, not two — identical visual output, existing component tests still green.

## Verified
- `/create` panels have real `backdrop-filter: blur(16px)` over `rgba(255,255,255,0.8)` — confirmed on an actual `.glass-panel-strong` node, and screenshotted at 1440px/390px (the exact screen the user flagged as unthemed — now translucent glass on the field).
- **No bare `bg-surface-raised`** remains in `routes/**`, `Roster.tsx`, `Toast.tsx` — pinned by a new unit test (`app/src/theme/glass-coverage.test.ts`) and a new e2e (`e2e/glass-coverage.spec.ts`) asserting the computed blur on `/create` + lobby.
- **AA (invariant 6)**: text-bearing panels reuse `--color-glass-strong`, whose worst-case-over-lightest-iris-stop ratio is already asserted in 00.4; nesting strong-on-strong only raises opacity toward white (can only improve contrast). No regression.
- **Focus glow**: grep confirms zero `outline-accent`/`focus-visible:outline-2` — the `--shadow-focus` glow is untouched app-wide.

## Deviation (called out)
Dropped leftover opaque `bg-surface` from `engine-ui/RankBoard.tsx` and `SortRound.tsx` mains — the same field-covering bug #53 fixed in `routes/**` but missed in `engine-ui/`. One-line, low-risk, consistent with "the field must show behind everything."

## Test evidence
`pnpm gate` green, verified independently in a clean install:
```
Test Files  40 passed (40)
     Tests  273 passed (273)
  74 passed (1.2m)   [desktop + mobile]
```

## Note
Coverage, not intensity — the glass is the same (deliberately subtle, AA-driven) strength as 00.4, now applied everywhere. If a bolder frost is wanted, that's a separate token tweak (`--glass-blur` / panel opacity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)