### PR TITLE
feat(02.3): Results wall

### DIFF
--- a/app/src/engine-ui/Plaque.tsx
+++ b/app/src/engine-ui/Plaque.tsx
@@ -1,0 +1,63 @@
+import type { Card } from '@values-cards/shared';
+import { Avatar } from '../components/Avatar';
+import { plaqueLayout } from './plaque-layout';
+
+export interface PlaqueProps {
+  name: string;
+  avatarHue: number;
+  gameTitle: string;
+  cards: Card[];
+  ranked: boolean;
+}
+
+/**
+ * One revealed result, rendered as a portable artifact: participant name + avatar,
+ * game title, that round's cards (order badges when ranked). Flexbox only, no
+ * grid/filters (architecture §12) — 04.1's satori export reads the same
+ * `plaque-layout.ts` data to render the identical artifact, so nothing here may use
+ * a CSS feature satori can't render. Purely presentational: the wall (02.3) owns
+ * spotlight affordances and round switching around this component, not inside it.
+ */
+export function Plaque({ name, avatarHue, gameTitle, cards, ranked }: PlaqueProps) {
+  return (
+    <div
+      className="flex flex-col rounded-card bg-surface-raised shadow-card"
+      style={{ width: plaqueLayout.width, padding: plaqueLayout.padding, gap: plaqueLayout.gap }}
+    >
+      <div className="flex items-center" style={{ gap: plaqueLayout.headerGap }}>
+        <Avatar name={name} hue={avatarHue} />
+        <div className="flex flex-col">
+          <p className="font-display font-semibold text-ink" style={{ fontSize: plaqueLayout.nameSize }}>
+            {name}
+          </p>
+          <p className="text-ink-muted" style={{ fontSize: plaqueLayout.titleSize }}>
+            {gameTitle}
+          </p>
+        </div>
+      </div>
+      <div role="list" className="flex flex-wrap" style={{ gap: plaqueLayout.cardGap }}>
+        {cards.map((card, index) => (
+          <div
+            key={card.value}
+            role="listitem"
+            className="flex flex-col items-center justify-center gap-1 rounded-control bg-accent-subtle text-center"
+            style={{ width: plaqueLayout.cardWidth, height: plaqueLayout.cardHeight, padding: plaqueLayout.cardGap }}
+          >
+            {ranked ? (
+              <span
+                aria-hidden="true"
+                className="flex items-center justify-center rounded-full bg-accent font-semibold text-on-accent"
+                style={{ width: plaqueLayout.badgeSize, height: plaqueLayout.badgeSize, fontSize: plaqueLayout.titleSize }}
+              >
+                {index + 1}
+              </span>
+            ) : null}
+            <p className="font-display font-semibold text-ink" style={{ fontSize: plaqueLayout.titleSize }}>
+              {card.value}
+            </p>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/app/src/engine-ui/plaque-layout.ts
+++ b/app/src/engine-ui/plaque-layout.ts
@@ -1,0 +1,20 @@
+/**
+ * The shared plaque layout: dimensions, spacing, and type scale as plain data (px
+ * numbers, no CSS). `Plaque.tsx` (screen) and 04.1's satori export both read this one
+ * definition so the exported artifact matches what participants saw on the wall —
+ * satori has no CSS custom-property support, so these can't live in `@theme` tokens.
+ */
+export const plaqueLayout = {
+  width: 340,
+  padding: 20,
+  gap: 16,
+  headerGap: 12,
+  cardWidth: 88,
+  cardHeight: 120,
+  cardGap: 10,
+  nameSize: 20,
+  titleSize: 13,
+  badgeSize: 22,
+} as const;
+
+export type PlaqueLayout = typeof plaqueLayout;

--- a/app/src/engine-ui/plaque.test.tsx
+++ b/app/src/engine-ui/plaque.test.tsx
@@ -1,0 +1,66 @@
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import type { Card } from '@values-cards/shared';
+import { Plaque } from './Plaque';
+
+afterEach(cleanup);
+
+const CARDS: Card[] = [
+  { value: 'Curiosity', description: 'd1' },
+  { value: 'Courage', description: 'd2' },
+  { value: 'Kindness', description: 'd3' },
+];
+
+describe('Plaque', () => {
+  it('renders the participant name, game title, and each card', () => {
+    render(<Plaque name="Ada" avatarHue={40} gameTitle="Values Night" cards={CARDS} ranked={false} />);
+    expect(screen.getByText('Ada')).not.toBeNull();
+    expect(screen.getByText('Values Night')).not.toBeNull();
+    for (const card of CARDS) expect(screen.getByText(card.value)).not.toBeNull();
+    expect(screen.queryByText('1')).toBeNull(); // no order badge when unranked
+  });
+
+  it('shows 1/2/3 order badges when ranked', () => {
+    render(<Plaque name="Ada" avatarHue={40} gameTitle="Values Night" cards={CARDS} ranked />);
+    expect(screen.getByText('1')).not.toBeNull();
+    expect(screen.getByText('2')).not.toBeNull();
+    expect(screen.getByText('3')).not.toBeNull();
+  });
+});
+
+// Architecture §12: the plaque layout is constrained to a satori-safe CSS subset
+// (flexbox, no grid/filters) so 04.1's satori export renders the identical artifact.
+// Source-scan (same technique as scripts/token-lint.mjs) rather than computed styles —
+// jsdom doesn't apply Tailwind's generated CSS, so class/style source is the only
+// reliable signal here.
+describe('plaque layout: satori-safe CSS subset', () => {
+  const DIR = dirname(fileURLToPath(import.meta.url));
+  const FORBIDDEN: Array<{ name: string; pattern: RegExp }> = [
+    { name: 'CSS grid', pattern: /\bgrid(-cols|-rows)?\b/ },
+    { name: 'filter', pattern: /\bfilter\s*:/ },
+    { name: 'backdrop-filter/backdrop-blur', pattern: /backdrop-(filter|blur)/ },
+    { name: 'clip-path', pattern: /clip-path/ },
+  ];
+
+  function violationsIn(file: string): string[] {
+    // Strip comments (`//` and `/* */`) — this scans actual class/style code, not
+    // this file's own prose about *why* those properties are forbidden.
+    const code = readFileSync(join(DIR, file), 'utf8')
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('\n')
+      .filter((line) => !line.trim().startsWith('//'))
+      .join('\n');
+    return FORBIDDEN.filter((rule) => rule.pattern.test(code)).map((rule) => rule.name);
+  }
+
+  it('Plaque.tsx uses none of the forbidden properties', () => {
+    expect(violationsIn('Plaque.tsx')).toEqual([]);
+  });
+
+  it('plaque-layout.ts uses none of the forbidden properties', () => {
+    expect(violationsIn('plaque-layout.ts')).toEqual([]);
+  });
+});

--- a/app/src/main.tsx
+++ b/app/src/main.tsx
@@ -5,6 +5,7 @@ import { Join } from './routes/Join';
 import { KitchenSink } from './routes/KitchenSink';
 import { Landing } from './routes/Landing';
 import { Sort } from './routes/Sort';
+import { Wall } from './routes/wall/Wall';
 import { MotionProvider } from './theme/motion';
 import './theme/tokens.css';
 
@@ -14,6 +15,7 @@ if (!rootElement) {
 }
 
 const JOIN_PATH_PATTERN = /^\/join(?:\/([A-Z0-9]{6}))?$/i;
+const WALL_PATH_PATTERN = /^\/wall\/([A-Z0-9]{6})$/i;
 
 // Still a hardcoded pathname check, not a router — `/sort` remains a fixed-config
 // demo entry point (wiring it to a real joined session is a later spec); a real
@@ -22,6 +24,8 @@ function currentRoute() {
   const path = window.location.pathname;
   const joinMatch = path.match(JOIN_PATH_PATTERN);
   if (joinMatch) return <Join code={joinMatch[1]} />;
+  const wallMatch = path.match(WALL_PATH_PATTERN);
+  if (wallMatch) return <Wall code={(wallMatch[1] as string).toUpperCase()} />;
   switch (path) {
     case '/create':
       return <Create />;

--- a/app/src/routes/Sort.tsx
+++ b/app/src/routes/Sort.tsx
@@ -1,11 +1,11 @@
 import { useEffect, useMemo, useRef } from 'react';
 import { GameConfigSchema, type Card, type GameConfig, type SessionState } from '@values-cards/shared';
 import { Button } from '../components/Button';
-import { GameCard } from '../components/GameCard';
 import { GatedContinue } from '../components/GatedContinue';
 import { RevealControl } from '../components/RevealControl';
 import { Roster } from '../components/Roster';
 import { Toast } from '../components/Toast';
+import { Plaque } from '../engine-ui/Plaque';
 import { RankBoard } from '../engine-ui/RankBoard';
 import { SortRound } from '../engine-ui/SortRound';
 import { TrimGrid } from '../engine-ui/TrimGrid';
@@ -192,18 +192,26 @@ function ActiveSort({
     };
   }, [useSortStore, config, participantId]);
 
+  // The wall (02.3) is the natural end state after the facilitator concludes —
+  // every connected participant hands off there automatically.
+  useEffect(() => {
+    if (state.phase === 'concluded') window.location.assign(`/wall/${code}`);
+  }, [state.phase, code]);
+
   return (
     <>
       <div className="fixed right-4 top-4 z-toast">
         <Roster participants={state.participants} selfId={participantId} collapsible />
       </div>
       <SortBody
+        code={code}
         config={config}
         useSortStore={useSortStore}
         phase={phase}
         byId={byId}
         gate={state.gate}
         participantId={participantId}
+        participant={state.participants[participantId]}
         reveals={state.reveals[participantId] ?? {}}
         send={send}
       />
@@ -212,21 +220,25 @@ function ActiveSort({
 }
 
 function SortBody({
+  code,
   config,
   useSortStore,
   phase,
   byId,
   gate,
   participantId,
+  participant,
   reveals,
   send,
 }: {
+  code: string;
   config: GameConfig;
   useSortStore: SortStoreHook;
   phase: ReturnType<typeof getPhase>;
   byId: Map<string, Card>;
   gate: SessionState['gate'];
   participantId: string;
+  participant: SessionState['participants'][string] | undefined;
   reveals: SessionState['reveals'][string];
   send: UseSessionResult['send'];
 }) {
@@ -265,6 +277,9 @@ function SortBody({
         </p>
         <GatedContinue gate={gate} nextRound={state.round + 1} onContinue={() => useSortStore.getState().continueRound()} />
         {roundCfg ? revealControlFor(roundCfg, cardsInOrder(state.kept, byId)) : null}
+        <a href={`/wall/${code}`} className="text-sm font-semibold text-accent underline">
+          View the wall
+        </a>
       </main>
     );
   }
@@ -293,7 +308,9 @@ function SortBody({
     );
   }
 
-  // result — local-only plaque preview; wall (02.3) and export (04.1) build on this later.
+  // result — the plaque preview (01.4); wall (02.3) and export (04.1) build on this
+  // same `Plaque` component, so what a participant previews here is exactly what
+  // the wall (and eventually the exported artifact) shows.
   const finalRoundCfg = config.rounds[state.round - 1];
   const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
   const isRanked = finalRoundCfg?.rank === true;
@@ -301,20 +318,22 @@ function SortBody({
     <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{config.title}</h1>
       <p className="text-ink-muted">Your final cards</p>
-      <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {finalCards.map((card, index) => (
-          <li key={card.value} className="flex flex-col items-center gap-2">
-            {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
-            <GameCard title={card.value} description={card.description} />
-          </li>
-        ))}
-      </ol>
+      <Plaque
+        name={participant?.name ?? 'You'}
+        avatarHue={participant?.avatarHue ?? 0}
+        gameTitle={config.title}
+        cards={finalCards}
+        ranked={isRanked}
+      />
       <div className="flex gap-4">
         {finalRoundCfg ? revealControlFor(finalRoundCfg, finalCards) : null}
         <Button variant="secondary" disabled title="Coming soon">
           Download
         </Button>
       </div>
+      <a href={`/wall/${code}`} className="text-sm font-semibold text-accent underline">
+        View the wall
+      </a>
     </main>
   );
 }
@@ -376,22 +395,15 @@ function DemoSort() {
     );
   }
 
-  // result — local-only plaque preview; reveal (02.2), wall (02.3) and
-  // export (04.1) build on this later.
+  // result — the plaque preview (01.4/02.3's `Plaque`); this standalone demo has no
+  // joined session, so Reveal/Download stay disabled here (SessionSort wires them up).
   const finalCards = cardsInOrder(state.ranking ?? state.kept, byId);
   const isRanked = DEMO_CONFIG.rounds[DEMO_CONFIG.rounds.length - 1]?.rank === true;
   return (
     <main className="flex min-h-screen flex-col items-center gap-6 p-8 text-ink">
       <h1 className="font-display text-2xl font-semibold">{DEMO_CONFIG.title}</h1>
       <p className="text-ink-muted">Your final cards</p>
-      <ol className="grid grid-cols-2 gap-4 sm:grid-cols-3">
-        {finalCards.map((card, index) => (
-          <li key={card.value} className="flex flex-col items-center gap-2">
-            {isRanked ? <p className="text-sm font-semibold text-ink-muted">{index + 1}</p> : null}
-            <GameCard title={card.value} description={card.description} />
-          </li>
-        ))}
-      </ol>
+      <Plaque name="You" avatarHue={0} gameTitle={DEMO_CONFIG.title} cards={finalCards} ranked={isRanked} />
       <div className="flex gap-4">
         <Button variant="secondary" disabled title="Coming soon">
           Reveal

--- a/app/src/routes/wall/Wall.test.tsx
+++ b/app/src/routes/wall/Wall.test.tsx
@@ -1,0 +1,125 @@
+import { cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { SessionState } from '@values-cards/shared';
+import { MotionProvider } from '../../theme/motion';
+import { WallBody } from './Wall';
+
+afterEach(cleanup);
+
+function baseState(overrides: Partial<SessionState> = {}): SessionState {
+  return {
+    code: 'ABC123',
+    config: {
+      title: 'Values Night',
+      deck: { name: 'Deck', cards: [{ value: 'Curiosity', description: 'd1' }, { value: 'Courage', description: 'd2' }] },
+      rounds: [{ name: 'Round 1', keep: 2, rank: false }],
+      theme: { variant: 'default' },
+      facilitated: false,
+    },
+    phase: 'active',
+    participants: {
+      facilitator: { name: 'Ada', avatarHue: 20, role: 'facilitator', connected: true, progress: { round: 1, sorted: 2, kept: 2, done: true } },
+      bea: { name: 'Bea', avatarHue: 200, role: 'participant', connected: true, progress: { round: 1, sorted: 2, kept: 2, done: true } },
+    },
+    reveals: {
+      bea: { 1: { cards: [{ value: 'Curiosity', description: 'd1' }, { value: 'Courage', description: 'd2' }], ranked: false, revealedAt: 1 } },
+    },
+    spotlight: null,
+    gate: null,
+    processedIntents: {},
+    processedJoins: {},
+    ...overrides,
+  };
+}
+
+function renderWall(state: SessionState, participantId: string, send = vi.fn()) {
+  render(
+    <MotionProvider>
+      <WallBody state={state} participantId={participantId} send={send} />
+    </MotionProvider>,
+  );
+  return send;
+}
+
+describe('WallBody', () => {
+  it('renders an empty-state invite when nobody has revealed yet', () => {
+    renderWall(baseState({ reveals: {} }), 'facilitator');
+    expect(screen.getByText(/No results yet/)).not.toBeNull();
+  });
+
+  it('renders a plaque for each revealed participant', () => {
+    renderWall(baseState(), 'facilitator');
+    expect(screen.getByText('Bea')).not.toBeNull();
+  });
+
+  it('lets the facilitator spotlight another participant plaque by keyboard', async () => {
+    const user = userEvent.setup();
+    const send = renderWall(baseState(), 'facilitator');
+    const tile = screen.getByRole('button', { name: "Spotlight Bea's round 1 result" });
+    tile.focus();
+    await user.keyboard('{Enter}');
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: 'setSpotlight', participantId: 'facilitator', target: 'bea' }));
+  });
+
+  it('enables the spotlight control for a participant\'s own plaque', () => {
+    renderWall(baseState(), 'bea', vi.fn());
+    const tile = screen.getByRole('button', { name: "Spotlight Bea's round 1 result" }) as HTMLButtonElement;
+    expect(tile.disabled).toBe(false);
+  });
+
+  it('disables spotlighting someone else\'s plaque for a non-facilitator participant', () => {
+    const state = baseState({
+      reveals: {
+        bea: { 1: { cards: [{ value: 'Curiosity', description: 'd1' }], ranked: false, revealedAt: 1 } },
+        facilitator: { 1: { cards: [{ value: 'Courage', description: 'd2' }], ranked: false, revealedAt: 1 } },
+      },
+    });
+    renderWall(state, 'bea');
+    const tile = screen.getByRole('button', { name: "Spotlight Ada's round 1 result" }) as HTMLButtonElement;
+    expect(tile.disabled).toBe(true);
+  });
+
+  it('does not announce anything on initial mount, even onto an already-spotlit wall', () => {
+    renderWall(baseState({ spotlight: 'bea' }), 'facilitator');
+    expect(screen.getByRole('status').textContent).toBe('');
+  });
+
+  it('announces a spotlight change via an aria-live region, on an actual transition', () => {
+    const send = vi.fn();
+    const { rerender } = render(
+      <MotionProvider>
+        <WallBody state={baseState()} participantId="facilitator" send={send} />
+      </MotionProvider>,
+    );
+    expect(screen.getByRole('status').textContent).toBe('');
+
+    rerender(
+      <MotionProvider>
+        <WallBody state={baseState({ spotlight: 'bea' })} participantId="facilitator" send={send} />
+      </MotionProvider>,
+    );
+    expect(screen.getByRole('status').textContent).toBe("Bea's result is now spotlighted");
+
+    rerender(
+      <MotionProvider>
+        <WallBody state={baseState({ spotlight: null })} participantId="facilitator" send={send} />
+      </MotionProvider>,
+    );
+    expect(screen.getByRole('status').textContent).toBe('Spotlight released');
+  });
+
+  it('disables every spotlight control once the session has concluded', () => {
+    renderWall(baseState({ phase: 'concluded' }), 'facilitator');
+    const tile = screen.getByRole('button', { name: "Spotlight Bea's round 1 result" }) as HTMLButtonElement;
+    expect(tile.disabled).toBe(true);
+  });
+
+  it('releases the spotlight on Escape when the local user is allowed to release', async () => {
+    const user = userEvent.setup();
+    const state = baseState({ spotlight: 'bea' });
+    const send = renderWall(state, 'facilitator');
+    await user.keyboard('{Escape}');
+    expect(send).toHaveBeenCalledWith(expect.objectContaining({ type: 'setSpotlight', participantId: 'facilitator', target: null }));
+  });
+});

--- a/app/src/routes/wall/Wall.tsx
+++ b/app/src/routes/wall/Wall.tsx
@@ -1,0 +1,322 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { motion } from 'framer-motion';
+import type { RevealSnapshot, SessionState } from '@values-cards/shared';
+import { Button } from '../../components/Button';
+import { Roster } from '../../components/Roster';
+import { Toast } from '../../components/Toast';
+import { Plaque } from '../../engine-ui/Plaque';
+import { intents } from '../../session/intents';
+import { ConnectionPill } from '../../session/ConnectionPill';
+import { loadToken } from '../../session/tokens';
+import type { UseSessionResult } from '../../session/useSession';
+import { useSession } from '../../session/useSession';
+import { fadeOnlyVariants, transition, useMotionSafe } from '../../theme/motion';
+
+export interface WallProps {
+  code: string;
+}
+
+/**
+ * `/wall/:code` (02.3): the shared results gallery. Reachable by every joined
+ * participant — including one who has revealed nothing — via the same session
+ * connection sort screens use, so reveals/un-reveals arrive live through `patch`
+ * events with no extra plumbing.
+ */
+export function Wall({ code }: WallProps) {
+  const token = useMemo(() => loadToken(code), [code]);
+  const { state, connection, send, error, clearError } = useSession(code);
+
+  useEffect(() => {
+    if (!token) window.location.assign(`/join/${code}`);
+  }, [token, code]);
+
+  useEffect(() => {
+    if (!error) return;
+    const timer = setTimeout(clearError, 4000);
+    return () => clearTimeout(timer);
+  }, [error, clearError]);
+
+  if (!token || !state || !state.participants[token.participantId]) {
+    return (
+      <main className="flex min-h-screen items-center justify-center text-ink">
+        <ConnectionPill connection={connection} />
+        <p>Loading…</p>
+      </main>
+    );
+  }
+
+  return (
+    <>
+      <ConnectionPill connection={connection} />
+      {error ? (
+        <div className="fixed inset-x-0 top-4 z-toast flex justify-center">
+          <Toast message={error.message} variant="danger" />
+        </div>
+      ) : null}
+      <WallBody state={state} participantId={token.participantId} send={send} />
+    </>
+  );
+}
+
+interface WallTileData {
+  participantId: string;
+  name: string;
+  avatarHue: number;
+  rounds: number[];
+  reveals: Record<number, RevealSnapshot>;
+}
+
+function buildTiles(state: SessionState): WallTileData[] {
+  return Object.entries(state.reveals)
+    .filter(([, rounds]) => Object.keys(rounds).length > 0)
+    .map(([participantId, rounds]) => {
+      const participant = state.participants[participantId];
+      return {
+        participantId,
+        name: participant?.name ?? 'Unknown',
+        avatarHue: participant?.avatarHue ?? 0,
+        rounds: Object.keys(rounds)
+          .map(Number)
+          .sort((a, b) => a - b),
+        reveals: rounds,
+      };
+    });
+}
+
+/** Presentational body — kept separate from `Wall` so it's testable without a real
+ *  WebSocket (mirrors routes/Sort.tsx's SortBody split). */
+export function WallBody({
+  state,
+  participantId,
+  send,
+}: {
+  state: SessionState;
+  participantId: string;
+  send: UseSessionResult['send'];
+}) {
+  const [projector, setProjector] = useState(false);
+  const [announcement, setAnnouncement] = useState('');
+  // Per-participant round switch (which of their revealed rounds is showing) — lifted
+  // here, not local to each tile, so the spotlight overlay agrees with the grid tile
+  // the viewer actually clicked instead of always assuming the newest round.
+  const [selectedRounds, setSelectedRounds] = useState<Record<string, number>>({});
+  const me = state.participants[participantId];
+  const isFacilitator = me?.role === 'facilitator';
+  const concluded = state.phase === 'concluded';
+  const spotlight = state.spotlight;
+  const tiles = useMemo(() => buildTiles(state), [state]);
+  const spotlitTile = tiles.find((tile) => tile.participantId === spotlight);
+  const canRelease = !concluded && spotlight !== null && (isFacilitator || spotlight === participantId);
+
+  function selectedRoundFor(tile: WallTileData): number {
+    const newest = tile.rounds[tile.rounds.length - 1] as number;
+    const stored = selectedRounds[tile.participantId];
+    return stored !== undefined && tile.rounds.includes(stored) ? stored : newest;
+  }
+
+  // Announce only on an actual spotlight *change* — a ref (not effect deps) skips the
+  // very first run, so mounting onto an already-spotlit (or already-clear) wall stays
+  // silent instead of always announcing "released" on load.
+  const hasMountedRef = useRef(false);
+  useEffect(() => {
+    if (!hasMountedRef.current) {
+      hasMountedRef.current = true;
+      return;
+    }
+    if (!spotlight) {
+      setAnnouncement('Spotlight released');
+      return;
+    }
+    const name = state.participants[spotlight]?.name ?? 'Someone';
+    setAnnouncement(`${name}'s result is now spotlighted`);
+  }, [spotlight, state.participants]);
+
+  useEffect(() => {
+    function onKeyDown(event: KeyboardEvent) {
+      if (event.key === 'Escape' && canRelease) {
+        send(intents.setSpotlight(participantId, null));
+      }
+    }
+    window.addEventListener('keydown', onKeyDown);
+    return () => window.removeEventListener('keydown', onKeyDown);
+  }, [canRelease, participantId, send]);
+
+  useEffect(() => {
+    function onFullscreenChange() {
+      setProjector(Boolean(document.fullscreenElement));
+    }
+    document.addEventListener('fullscreenchange', onFullscreenChange);
+    return () => document.removeEventListener('fullscreenchange', onFullscreenChange);
+  }, []);
+
+  async function toggleProjector() {
+    if (!document.fullscreenElement) {
+      await document.documentElement.requestFullscreen?.().catch(() => {});
+      setProjector(true);
+    } else {
+      await document.exitFullscreen?.().catch(() => {});
+      setProjector(false);
+    }
+  }
+
+  function spotlightIntentFor(tile: WallTileData) {
+    return intents.setSpotlight(participantId, spotlight === tile.participantId ? null : tile.participantId);
+  }
+
+  return (
+    <main
+      data-projector={projector}
+      className="flex min-h-screen flex-col items-center gap-6 p-6 text-ink sm:p-8"
+    >
+      <div aria-live="polite" role="status" className="sr-only">
+        {announcement}
+      </div>
+
+      {projector ? (
+        <Button variant="ghost" size="sm" className="fixed right-4 top-4 z-toast" onClick={toggleProjector}>
+          Exit projector
+        </Button>
+      ) : (
+        <div className="flex w-full max-w-5xl flex-wrap items-center justify-between gap-4">
+          <h1 className="font-display text-2xl font-semibold">{state.config.title} · Wall</h1>
+          <div className="flex items-center gap-3">
+            {concluded ? <p role="status" className="text-sm text-ink-muted">Concluded · read-only</p> : null}
+            <Roster participants={state.participants} selfId={participantId} collapsible />
+            <Button variant="secondary" size="sm" onClick={toggleProjector}>
+              Projector mode
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {tiles.length === 0 ? (
+        <p className={`glass-panel-strong rounded-control p-4 text-ink-muted ${projector ? 'text-2xl' : ''}`}>
+          No results yet — reveal your cards to add your plaque to the wall.
+        </p>
+      ) : (
+        <div className="grid w-full max-w-5xl grid-cols-1 gap-6 md:grid-cols-2 xl:grid-cols-3">
+          {tiles.map((tile) => (
+            <WallTile
+              key={tile.participantId}
+              tile={tile}
+              gameTitle={state.config.title}
+              selected={selectedRoundFor(tile)}
+              onSelectRound={(round) => setSelectedRounds((prev) => ({ ...prev, [tile.participantId]: round }))}
+              dimmed={spotlight !== null && spotlight !== tile.participantId}
+              canSpotlight={!concluded && (isFacilitator || tile.participantId === participantId)}
+              projector={projector}
+              onToggleSpotlight={() => send(spotlightIntentFor(tile))}
+            />
+          ))}
+        </div>
+      )}
+
+      {spotlitTile ? (
+        <SpotlightOverlay
+          tile={spotlitTile}
+          round={selectedRoundFor(spotlitTile)}
+          gameTitle={state.config.title}
+          canRelease={canRelease}
+          onRelease={() => send(intents.setSpotlight(participantId, null))}
+        />
+      ) : null}
+    </main>
+  );
+}
+
+function WallTile({
+  tile,
+  gameTitle,
+  selected,
+  onSelectRound,
+  dimmed,
+  canSpotlight,
+  projector,
+  onToggleSpotlight,
+}: {
+  tile: WallTileData;
+  gameTitle: string;
+  selected: number;
+  onSelectRound: (round: number) => void;
+  dimmed: boolean;
+  canSpotlight: boolean;
+  projector: boolean;
+  onToggleSpotlight: () => void;
+}) {
+  const snapshot = tile.reveals[selected];
+  if (!snapshot) return null;
+
+  return (
+    <div className={`flex flex-col items-center gap-2 transition-opacity ${dimmed ? 'opacity-30' : ''}`}>
+      <button
+        type="button"
+        onClick={canSpotlight ? onToggleSpotlight : undefined}
+        disabled={!canSpotlight}
+        aria-label={`Spotlight ${tile.name}'s round ${selected} result`}
+        className="block rounded-card focus-visible:outline-none focus-visible:shadow-focus disabled:cursor-default"
+      >
+        <Plaque name={tile.name} avatarHue={tile.avatarHue} gameTitle={gameTitle} cards={snapshot.cards} ranked={snapshot.ranked} />
+      </button>
+      {tile.rounds.length > 1 ? (
+        <div role="group" aria-label={`${tile.name}'s revealed rounds`} className="flex gap-2">
+          {tile.rounds.map((round) => (
+            <button
+              key={round}
+              type="button"
+              onClick={() => onSelectRound(round)}
+              aria-pressed={round === selected}
+              className={`min-h-11 min-w-11 rounded-control px-3 font-semibold ${projector ? 'text-lg' : 'text-sm'} ${
+                round === selected ? 'bg-accent text-on-accent' : 'bg-accent-subtle text-ink-muted'
+              }`}
+            >
+              R{round}
+            </button>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+const SPOTLIGHT_VARIANTS = {
+  hidden: { opacity: 0, scale: 0.85 },
+  shown: { opacity: 1, scale: 1 },
+};
+const SPOTLIGHT_SPRING = { type: 'spring' as const, stiffness: 420, damping: 32 };
+
+function SpotlightOverlay({
+  tile,
+  round,
+  gameTitle,
+  canRelease,
+  onRelease,
+}: {
+  tile: WallTileData;
+  round: number;
+  gameTitle: string;
+  canRelease: boolean;
+  onRelease: () => void;
+}) {
+  const motionSafe = useMotionSafe();
+  const variants = fadeOnlyVariants(SPOTLIGHT_VARIANTS, motionSafe);
+  const snapshot = tile.reveals[round];
+  if (!snapshot) return null;
+
+  return (
+    <div className="fixed inset-0 z-modal flex flex-col items-center justify-center gap-4 bg-ink/40 p-6">
+      <motion.div
+        initial="hidden"
+        animate="shown"
+        variants={variants}
+        transition={transition(motionSafe, SPOTLIGHT_SPRING)}
+      >
+        <Plaque name={tile.name} avatarHue={tile.avatarHue} gameTitle={gameTitle} cards={snapshot.cards} ranked={snapshot.ranked} />
+      </motion.div>
+      {canRelease ? (
+        <Button variant="secondary" onClick={onRelease}>
+          Release spotlight
+        </Button>
+      ) : null}
+    </div>
+  );
+}

--- a/e2e/round-flow-refresh.spec.ts
+++ b/e2e/round-flow-refresh.spec.ts
@@ -100,7 +100,8 @@ test('refresh during RankBoard preserves the exact rank order (invariant 4)', as
 
   // Ranking round-trips onto the result screen too, including through a
   // second refresh once it's the terminal state (the result screen's cards
-  // aren't numbered paragraphs like RankBoard's, so read the GameCard title).
+  // are the Plaque component's (02.3) mini cards, not RankBoard's numbered
+  // paragraphs — read the plaque card's title).
   //
   // dnd-kit stops propagation on the synthetic click that trails a pointer
   // drag for 50ms after pointerup (browsers fire that click regardless of
@@ -113,7 +114,7 @@ test('refresh during RankBoard preserves the exact rank order (invariant 4)', as
     const count = await cards.count();
     const names: string[] = [];
     for (let i = 0; i < count; i++) {
-      names.push((await cards.nth(i).locator('h3').first().textContent()) ?? '');
+      names.push((await cards.nth(i).locator('p').first().textContent()) ?? '');
     }
     return names;
   };

--- a/e2e/wall.spec.ts
+++ b/e2e/wall.spec.ts
@@ -1,0 +1,236 @@
+import { expect, test, type Page } from '@playwright/test';
+
+/** One round, unranked, keep-all-4 — the wall itself is the thing under test, not
+ *  round mechanics (already covered by reveal.spec.ts). */
+const CONFIG = {
+  title: 'Wall E2E',
+  deck: {
+    name: 'Mini',
+    cards: [
+      { value: 'Alpha', description: 'd' },
+      { value: 'Beta', description: 'd' },
+      { value: 'Gamma', description: 'd' },
+      { value: 'Delta', description: 'd' },
+    ],
+  },
+  rounds: [{ name: 'Round 1', keep: 4, rank: false }],
+  theme: { variant: 'default' },
+  facilitated: false,
+};
+
+async function joinAs(page: Page, code: string, name: string, creatorToken?: string) {
+  await page.goto(`/join/${code}`);
+  if (creatorToken) {
+    await page.evaluate(
+      ({ code: c, token }) => sessionStorage.setItem(`vc:${c}:creatorToken`, token),
+      { code, token: creatorToken },
+    );
+  }
+  await page.getByLabel('Display name').fill(name);
+  await page.getByRole('button', { name: 'Join' }).click();
+  await expect(page).toHaveURL(/\/sort$/, { timeout: 10_000 });
+}
+
+async function revealAll(page: Page) {
+  for (let i = 0; i < 4; i++) {
+    const remainingBefore = 4 - i;
+    await page.getByRole('button', { name: /^Keep /, exact: false }).first().click();
+    if (remainingBefore - 1 > 0) {
+      // Wait for the sort store's next card to actually mount before the next click —
+      // firing all four clicks back to back can outrun the re-render (see reveal.spec.ts's
+      // resolveQueue, which does the same).
+      await expect(page.getByText(`${remainingBefore - 1} left`)).toBeVisible({ timeout: 5000 });
+    }
+  }
+  await expect(page.getByRole('button', { name: 'Reveal' })).toBeVisible({ timeout: 10_000 });
+  await page.getByRole('button', { name: 'Reveal' }).click();
+  const explainer = page.getByRole('dialog');
+  if (await explainer.isVisible().catch(() => false)) {
+    await page.getByRole('button', { name: 'Got it, share' }).click();
+  }
+  await expect(page.getByRole('status').filter({ hasText: 'Shared ✓' })).toBeVisible({ timeout: 10_000 });
+}
+
+async function createSession(request: import('@playwright/test').APIRequestContext) {
+  return (await (await request.post('/api/session', { data: { config: CONFIG } })).json()) as {
+    code: string;
+    creatorToken: string;
+  };
+}
+
+test('wall: reveal/un-reveal are live across browsers with no refresh', async ({ browser, request }) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  const created = await createSession(request);
+  await joinAs(pageA, created.code, 'Ada', created.creatorToken);
+  await joinAs(pageB, created.code, 'Bea');
+  // Starting the game is a single shared-session mutation (the facilitator's) — every
+  // connected participant, B included, sees phase flip to `active` from that one click.
+  await pageA.getByRole('button', { name: 'Start game' }).click();
+
+  await pageB.goto(`/wall/${created.code}`);
+  await expect(pageB.getByText(/No results yet/)).toBeVisible({ timeout: 10_000 });
+
+  await revealAll(pageA);
+
+  // B's already-open wall gains Ada's plaque with no reload.
+  await expect(pageB.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByText('Alpha')).toBeVisible();
+
+  await pageA.getByRole('button', { name: 'Un-reveal' }).click();
+  await expect(pageB.getByText('Ada')).not.toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByText(/No results yet/)).toBeVisible();
+
+  await contextA.close();
+  await contextB.close();
+});
+
+test('wall: spotlight enlarges on every view and only the facilitator or owner may release; a participant may not spotlight another', async ({
+  browser,
+  request,
+}) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  const created = await createSession(request);
+  await joinAs(pageA, created.code, 'Ada', created.creatorToken); // facilitator
+  await joinAs(pageB, created.code, 'Bea');
+  await pageA.getByRole('button', { name: 'Start game' }).click();
+  await revealAll(pageA);
+  await revealAll(pageB);
+
+  await pageA.goto(`/wall/${created.code}`);
+  await pageB.goto(`/wall/${created.code}`);
+  await expect(pageA.getByText('Bea')).toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByText('Bea')).toBeVisible({ timeout: 10_000 });
+
+  // Bea (non-facilitator) cannot spotlight Ada's plaque — the control is disabled.
+  const beaOnPageB = pageB.getByRole('button', { name: "Spotlight Ada's round 1 result" });
+  await expect(beaOnPageB).toBeDisabled();
+
+  // The facilitator spotlights Bea — it enlarges (a "Release spotlight" affordance
+  // appears) on both connected wall views.
+  await pageA.getByRole('button', { name: "Spotlight Bea's round 1 result" }).click();
+  await expect(pageA.getByRole('button', { name: 'Release spotlight' })).toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByRole('button', { name: 'Release spotlight' })).toBeVisible({ timeout: 10_000 });
+
+  // Bea owns the spotlit plaque, so she may release it too (Esc).
+  await pageB.keyboard.press('Escape');
+  await expect(pageA.getByRole('button', { name: 'Release spotlight' })).not.toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByRole('button', { name: 'Release spotlight' })).not.toBeVisible({ timeout: 10_000 });
+
+  await contextA.close();
+  await contextB.close();
+});
+
+test('wall: projector mode hides chrome and stays live', async ({ browser, request }) => {
+  const contextA = await browser.newContext();
+  const contextB = await browser.newContext();
+  const pageA = await contextA.newPage();
+  const pageB = await contextB.newPage();
+
+  const created = await createSession(request);
+  await joinAs(pageA, created.code, 'Ada', created.creatorToken);
+  await joinAs(pageB, created.code, 'Bea');
+  await pageA.getByRole('button', { name: 'Start game' }).click();
+
+  await pageB.goto(`/wall/${created.code}`);
+  await expect(pageB.getByRole('heading', { name: /Wall/ })).toBeVisible({ timeout: 10_000 });
+
+  await pageB.getByRole('button', { name: 'Projector mode' }).click();
+  await expect(pageB.getByRole('heading', { name: /Wall/ })).not.toBeVisible({ timeout: 10_000 });
+  await expect(pageB.getByRole('button', { name: 'Exit projector' })).toBeVisible();
+
+  await revealAll(pageA);
+  await expect(pageB.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+
+  await contextA.close();
+  await contextB.close();
+});
+
+test('wall: a concluded session remains reachable, and is actually read-only (server rejects mutation)', async ({
+  browser,
+  request,
+}) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const created = await createSession(request);
+  await joinAs(page, created.code, 'Ada', created.creatorToken);
+  await page.getByRole('button', { name: 'Start game' }).click();
+  await revealAll(page);
+
+  const participantId = await page.evaluate(
+    (code) => (JSON.parse(localStorage.getItem(`vc:${code}:token`) ?? '{}') as { participantId?: string }).participantId,
+    created.code,
+  );
+  // `conclude` sent while still on /sort — routes/Sort.tsx auto-redirects to the wall
+  // once phase flips to `concluded` (the wall is the natural end state), so this test
+  // waits for that redirect rather than racing it with its own `page.goto`.
+  await page.evaluate((id) => {
+    (window as unknown as { __VC_TEST__?: { send: (intent: Record<string, unknown>) => void } }).__VC_TEST__?.send({
+      type: 'conclude',
+      intentId: crypto.randomUUID(),
+      participantId: id,
+    });
+  }, participantId);
+
+  await expect(page).toHaveURL(new RegExp(`/wall/${created.code}$`), { timeout: 10_000 });
+  await expect(page.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText('Alpha')).toBeVisible();
+  await expect(page.getByText('Concluded · read-only', { exact: true })).toBeVisible();
+
+  // The spotlight control is disabled in the UI...
+  await expect(page.getByRole('button', { name: "Spotlight Ada's round 1 result" })).toBeDisabled();
+
+  // ...and the DO itself — the one writer (tenet 1) — rejects a spotlight mutation even
+  // sent directly, bypassing the disabled control: read-only is enforced server-side, not
+  // just by the client hiding a button.
+  await page.evaluate((id) => {
+    (window as unknown as { __VC_TEST__?: { send: (intent: Record<string, unknown>) => void } }).__VC_TEST__?.send({
+      type: 'setSpotlight',
+      intentId: crypto.randomUUID(),
+      participantId: id,
+      target: id,
+    });
+  }, participantId);
+  await expect(
+    page.getByText('this session has concluded; the wall is read-only', { exact: true }),
+  ).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByRole('button', { name: 'Release spotlight' })).toHaveCount(0);
+
+  await page.reload();
+  await expect(page.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+
+  await context.close();
+});
+
+test('wall: responsive — single column at 390px, multi-column grid at 1440px', async ({ browser, request }) => {
+  const context = await browser.newContext();
+  const page = await context.newPage();
+
+  const created = await createSession(request);
+  await joinAs(page, created.code, 'Ada', created.creatorToken);
+  await page.getByRole('button', { name: 'Start game' }).click();
+  await revealAll(page);
+  await page.goto(`/wall/${created.code}`);
+  await expect(page.getByText('Ada')).toBeVisible({ timeout: 10_000 });
+
+  const grid = page.locator('[class*="grid"]', { has: page.getByText('Ada') }).first();
+
+  await page.setViewportSize({ width: 390, height: 844 });
+  await expect(grid).toHaveCSS('grid-template-columns', /^[^ ]+$/); // exactly one track
+  await page.screenshot({ path: 'test-results/wall-mobile-390.png' });
+
+  await page.setViewportSize({ width: 1440, height: 900 });
+  const desktopColumns = await grid.evaluate((el) => getComputedStyle(el).gridTemplateColumns.split(' ').length);
+  expect(desktopColumns).toBeGreaterThan(1);
+  await page.screenshot({ path: 'test-results/wall-desktop-1440.png' });
+
+  await context.close();
+});

--- a/shared/src/engine/apply-intent.test.ts
+++ b/shared/src/engine/apply-intent.test.ts
@@ -343,6 +343,40 @@ describe('applyIntent: setSpotlight', () => {
     if ('rejection' in result) throw new Error('unexpected rejection');
     expect(result.state.spotlight).toBe(PARTICIPANT);
   });
+
+  it('lets the owner release their own spotlight with target: null', () => {
+    const state = baseState({ spotlight: PARTICIPANT });
+    const result = applyIntent(state, {
+      type: 'setSpotlight',
+      intentId: 'i1',
+      participantId: PARTICIPANT,
+      target: null,
+    });
+    if ('rejection' in result) throw new Error('unexpected rejection');
+    expect(result.state.spotlight).toBeNull();
+  });
+
+  it('rejects a non-facilitator clearing someone else\'s spotlight', () => {
+    const state = baseState({ spotlight: FACILITATOR });
+    const result = applyIntent(state, {
+      type: 'setSpotlight',
+      intentId: 'i1',
+      participantId: PARTICIPANT,
+      target: null,
+    });
+    expect('rejection' in result).toBe(true);
+  });
+
+  it('rejects spotlighting once the session has concluded — the wall is read-only', () => {
+    const state = baseState({ phase: 'concluded' });
+    const result = applyIntent(state, {
+      type: 'setSpotlight',
+      intentId: 'i1',
+      participantId: FACILITATOR,
+      target: PARTICIPANT,
+    });
+    expect('rejection' in result).toBe(true);
+  });
 });
 
 describe('applyIntent: conclude', () => {

--- a/shared/src/engine/apply-intent.ts
+++ b/shared/src/engine/apply-intent.ts
@@ -222,8 +222,17 @@ export function applyIntent(state: SessionState, intent: Intent, deps: ApplyInte
     case 'setSpotlight': {
       const participant = requireParticipant(state, intent.participantId);
       if (!participant) return reject('UNKNOWN_PARTICIPANT', 'no participant with that id');
+      // The wall (spec 02.3) is read-only once the facilitator concludes — the DO is the
+      // one writer (tenet 1), so this is enforced here, not just by a disabled client control.
+      if (state.phase === 'concluded') {
+        return reject('SESSION_CONCLUDED', 'this session has concluded; the wall is read-only');
+      }
       const spotlightingSelf = intent.target === intent.participantId;
-      if (!spotlightingSelf && participant.role !== 'facilitator') {
+      // Releasing (`target: null`) is the mirror of self-spotlighting, not "spotlighting
+      // someone else" — the owner of the current spotlight may always clear it (spec
+      // 02.3: "facilitator or the owner, for self-spotlight, releases with null").
+      const releasingOwnSpotlight = intent.target === null && state.spotlight === intent.participantId;
+      if (!spotlightingSelf && !releasingOwnSpotlight && participant.role !== 'facilitator') {
         return reject('FORBIDDEN', 'only the facilitator can spotlight another participant');
       }
       const next = recordProcessed({ ...state, spotlight: intent.target }, intent.participantId, intent.intentId);

--- a/specs/02-multiplayer/02.3-results-wall.md
+++ b/specs/02-multiplayer/02.3-results-wall.md
@@ -46,23 +46,25 @@ spotlight.
 - Commonality analytics → 2.1 (PRD §9).
 
 ## Acceptance criteria
-- [ ] Plaque renders name, title, themed cards; ranked plaque shows order badges
+- [x] Plaque renders name, title, themed cards; ranked plaque shows order badges
       (component test `app/src/engine-ui/plaque.test.tsx`).
-- [ ] Plaque layout uses only the satori-safe subset — a unit test walks
+- [x] Plaque layout uses only the satori-safe subset — a unit test walks
       `plaque-layout.ts`/rendered styles for forbidden properties (list in test).
-- [ ] Two-browser E2E `e2e/wall.spec.ts`: A reveals → plaque appears on B's open wall
+- [x] Two-browser E2E `e2e/wall.spec.ts`: A reveals → plaque appears on B's open wall
       without refresh; A un-reveals → it disappears.
-- [ ] Spotlight E2E: facilitator spotlights A's plaque → it enlarges on both browsers;
+- [x] Spotlight E2E: facilitator spotlights A's plaque → it enlarges on both browsers;
       release restores the grid. A participant can spotlight only their own plaque
       (attempt on another's is rejected — asserts error toast / disabled control).
-- [ ] Projector mode hides chrome and remains live (E2E toggles fullscreen and receives
+- [x] Projector mode hides chrome and remains live (E2E toggles fullscreen and receives
       a new reveal).
-- [ ] Wall of a `concluded` session renders read-only (E2E: conclude, reload wall).
-- [ ] Wall is responsive: 390px mobile shows single-column plaques; 1440px shows grid
+- [x] Wall of a `concluded` session renders read-only (E2E: conclude, reload wall;
+      server-side enforced in `shared/src/engine/apply-intent.ts`'s `setSpotlight`, not
+      just a disabled client control).
+- [x] Wall is responsive: 390px mobile shows single-column plaques; 1440px shows grid
       (E2E screenshots at both viewports).
-- [ ] Keyboard: plaques and spotlight controls reachable and operable by keyboard;
+- [x] Keyboard: plaques and spotlight controls reachable and operable by keyboard;
       spotlight change is announced (`aria-live`) (component test).
-- [ ] `pnpm gate` green.
+- [x] `pnpm gate` green.
 
 ## Gate
 ```bash

--- a/specs/status.json
+++ b/specs/status.json
@@ -107,7 +107,7 @@
       "depends_on": [
         "02.2"
       ],
-      "status": "not-started"
+      "status": "done"
     },
     {
       "id": "03.1",


### PR DESCRIPTION
Spec: [`specs/02-multiplayer/02.3-results-wall.md`](specs/02-multiplayer/02.3-results-wall.md)

Live gallery of revealed plaques at `/wall/:code` — projector-friendly, with spotlight.

## What landed
- **`Plaque`** (`app/src/engine-ui/Plaque.tsx`) — one revealed result: name + avatar, game title, that round's cards, order badges when ranked. Flexbox only, no grid/filters.
- **`plaque-layout.ts`** — dimensions/spacing/type scale as plain data (px numbers), the single definition 04.1's satori export will also read so the artifact matches the screen. Deliberately not `@theme` tokens: satori has no CSS custom-property support.
- **01.4's result-screen preview refactored onto `Plaque`** rather than forked.
- **Wall route** — one plaque per revealed (participant, round), grouped by participant, newest round by default with a per-plaque round switcher; empty state invites reveals. Live via `patch` events, no refresh.
- **Projector mode** — Fullscreen API toggle, hides all chrome except plaques, token-backed type bumps on chrome.
- **Spotlight** — facilitator may spotlight anyone, a participant only themselves; spotlit plaque centers on every connected view, others dim. `Esc` releases only when permitted. Reduced-motion crossfades instead of scaling.

## ⚠️ Engine change — please review closely
This touches shared contract behaviour in `shared/src/engine/apply-intent.ts`, so it deserves more scrutiny than the UI:

1. **Bug fix — owner could not release their own spotlight.** The self-check was `intent.target === intent.participantId`, so releasing with `target: null` fell through to the "spotlighting someone else" rejection unless you were the facilitator — contradicting the spec's explicit "the owner, for self-spotlight, releases with `null`" rule. Added a `releasingOwnSpotlight` check. A non-owner non-facilitator sending `null` is still rejected.
2. **`concluded` guard added to `setSpotlight`** — read-only is enforced in the engine (tenet 1: the DO is the one writer), not just by a disabled control.

Both have new unit tests in `shared/src/engine/apply-intent.test.ts`.

## Acceptance criteria — all 9 checked, each backed by a passing command
- [x] Plaque renders name, title, themed cards; ranked shows order badges
- [x] Layout uses only the satori-safe subset (unit test walks for forbidden properties)
- [x] Two-browser E2E: A reveals → appears on B's open wall without refresh; un-reveal → disappears
- [x] Spotlight E2E: enlarges on both browsers, release restores grid, participant may spotlight only their own
- [x] Projector mode hides chrome and remains live
- [x] Concluded session renders read-only
- [x] Responsive: single column at 390px, grid at 1440px
- [x] Keyboard reachable/operable; spotlight change announced via `aria-live`
- [x] `pnpm gate` green

## Test evidence
Gate re-run independently in the worktree by the orchestrator, not just self-reported:
```
pnpm gate                                  -> green
  typecheck (shared/decks/app/party), lint, token:lint  clean
  test:unit   289 passed (42 files)
  test:e2e     84 passed (1.3m)
pnpm exec playwright test e2e/wall.spec.ts -> 10 passed (desktop + mobile chromium)
```

## Deviations
- **`Plaque`'s own type does not scale in projector mode.** It's a satori-locked fixed-size artifact (architecture §12), so distance readability comes from hiding chrome and the responsive grid, not a font bump on the plaque. Chrome type does bump, via tokens.
- `Plaque` stays on opaque `bg-surface-raised` — intentional per 00.5, which keeps export/plaque surfaces opaque because satori can't render `backdrop-filter`.

## Known follow-up (not in this spec's scope)
`reveal`/`unreveal` still have no `concluded` guard, so read-only is currently enforced for spotlight but not for reveals. The wall UI can't initiate a reveal after conclude (Sort redirects), so this isn't reachable through the product — but it's a server-side inconsistency worth closing in **04.2 Hardening**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)